### PR TITLE
feat: export clips as Sportscode-compatible XML

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -188,6 +188,7 @@
       "exportDataSuccess": "Daten von {{count}} Clip(s) nach {{path}} exportiert",
       "exportDataError": "Fehler beim Exportieren der Clip-Daten",
       "saveSession": "Sitzung speichern",
+      "exportSportscode": "Sportscode-XML exportieren",
       "saveSessionSuccess": "Analyse-Sitzung erfolgreich gespeichert",
       "saveSessionError": "Fehler beim Speichern der Analyse-Sitzung",
       "quickTagCreated": "Clip erstellt: {{category}}",

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -188,6 +188,7 @@
       "exportDataSuccess": "Εξήχθησαν δεδομένα {{count}} κλιπ στο {{path}}",
       "exportDataError": "Σφάλμα κατά την εξαγωγή των δεδομένων κλιπ",
       "saveSession": "Αποθήκευση συνεδρίας",
+      "exportSportscode": "Εξαγωγή XML Sportscode",
       "saveSessionSuccess": "Η συνεδρία ανάλυσης αποθηκεύτηκε με επιτυχία",
       "saveSessionError": "Σφάλμα κατά την αποθήκευση της συνεδρίας ανάλυσης",
       "quickTagCreated": "Δημιουργήθηκε κλιπ: {{category}}",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -188,6 +188,7 @@
       "exportDataSuccess": "Exported {{count}} clip(s) data to {{path}}",
       "exportDataError": "Error exporting clips data",
       "saveSession": "Save Session",
+      "exportSportscode": "Export Sportscode XML",
       "saveSessionSuccess": "Analysis session saved successfully",
       "saveSessionError": "Error saving analysis session",
       "quickTagCreated": "Clip created: {{category}}",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -188,6 +188,7 @@
       "exportDataSuccess": "Se han exportado los datos de {{count}} clip(s) a {{path}}",
       "exportDataError": "Error al exportar los datos de los clips",
       "saveSession": "Guardar sesión",
+      "exportSportscode": "Exportar XML de Sportscode",
       "saveSessionSuccess": "Sesión de análisis guardada correctamente",
       "saveSessionError": "Error al guardar la sesión de análisis",
       "quickTagCreated": "Clip creado: {{category}}",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -188,6 +188,7 @@
       "exportDataSuccess": "Données de {{count}} clip(s) exportées vers {{path}}",
       "exportDataError": "Erreur lors de l'exportation des données des clips",
       "saveSession": "Enregistrer la session",
+      "exportSportscode": "Exporter le XML Sportscode",
       "saveSessionSuccess": "Session d'analyse enregistrée avec succès",
       "saveSessionError": "Erreur lors de l'enregistrement de la session d'analyse",
       "quickTagCreated": "Clip créé : {{category}}",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -188,6 +188,7 @@
       "exportDataSuccess": "Esportati i dati di {{count}} clip in {{path}}",
       "exportDataError": "Errore durante l'esportazione dei dati delle clip",
       "saveSession": "Salva sessione",
+      "exportSportscode": "Esporta XML Sportscode",
       "saveSessionSuccess": "Sessione di analisi salvata correttamente",
       "saveSessionError": "Errore durante il salvataggio della sessione di analisi",
       "quickTagCreated": "Clip creata: {{category}}",

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -188,6 +188,7 @@
       "exportDataSuccess": "Eksportuoti {{count}} klipų duomenys į {{path}}",
       "exportDataError": "Klaida eksportuojant klipų duomenis",
       "saveSession": "Išsaugoti sesiją",
+      "exportSportscode": "Eksportuoti Sportscode XML",
       "saveSessionSuccess": "Analizės sesija sėkmingai išsaugota",
       "saveSessionError": "Klaida išsaugant analizės sesiją",
       "quickTagCreated": "Klipas sukurtas: {{category}}",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -179,6 +179,7 @@
       "exportDataSuccess": "Dados de {{count}} clip(s) exportados para {{path}}",
       "exportDataError": "Erro ao exportar dados dos clips",
       "saveSession": "Guardar Sessão",
+      "exportSportscode": "Exportar XML Sportscode",
       "saveSessionSuccess": "Sessão de análise guardada com sucesso",
       "saveSessionError": "Erro ao guardar sessão de análise",
       "quickTagCreated": "Clip criado: {{category}}",

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -188,6 +188,7 @@
       "exportDataSuccess": "Izvoženi podatki za {{count}} posnetkov v {{path}}",
       "exportDataError": "Napaka pri izvozu podatkov posnetkov",
       "saveSession": "Shrani sejo",
+      "exportSportscode": "Izvozi XML Sportscode",
       "saveSessionSuccess": "Analitska seja je bila uspešno shranjena",
       "saveSessionError": "Napaka pri shranjevanju analitske seje",
       "quickTagCreated": "Posnetek ustvarjen: {{category}}",

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -188,6 +188,7 @@
       "exportDataSuccess": "Izvezeno {{count}} klip(ova) podataka u {{path}}",
       "exportDataError": "Greška pri izvozu podataka o klipovima",
       "saveSession": "Sačuvaj sesiju",
+      "exportSportscode": "Izvezi Sportscode XML",
       "saveSessionSuccess": "Analitička sesija uspešno sačuvana",
       "saveSessionError": "Greška pri čuvanju analitičke sesije",
       "quickTagCreated": "Klip napravljen: {{category}}",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -188,6 +188,7 @@
       "exportDataSuccess": "{{count}} klip verisi {{path}} konumuna aktarıldı",
       "exportDataError": "Klip verileri dışa aktarılırken hata oluştu",
       "saveSession": "Oturumu Kaydet",
+      "exportSportscode": "Sportscode XML dışa aktar",
       "saveSessionSuccess": "Analiz oturumu başarıyla kaydedildi",
       "saveSessionError": "Analiz oturumu kaydedilirken hata oluştu",
       "quickTagCreated": "Klip oluşturuldu: {{category}}",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1527,6 +1527,112 @@ ipcMain.handle(
   }
 );
 
+// Export clips as a Sportscode-compatible timeline XML
+ipcMain.handle("export-clips-xml", async (_event, projectId: number) => {
+  try {
+    const result = await dialog.showSaveDialog(mainWindow, {
+      title: "Export Sportscode XML",
+      defaultPath: path.join(
+        app.getPath("documents"),
+        `${(getProjectById(projectId)?.name || "clips").replace(/[^a-zA-Z0-9]/g, "_")}-sportscode.xml`
+      ),
+      filters: [{ name: "XML", extensions: ["xml"] }],
+    });
+
+    if (result.canceled || !result.filePath) return null;
+
+    const clips = getClips(projectId);
+    const categories = getCategories(projectId);
+    const categoryName = new Map<number, string>();
+    const categoryColor = new Map<number, string>();
+    categories.forEach(cat => {
+      if (cat.id) {
+        categoryName.set(cat.id, cat.name);
+        categoryColor.set(cat.id, cat.color);
+      }
+    });
+    const players = getPlayers(projectId);
+    const playerLabel = new Map<number, string>();
+    players.forEach(p => {
+      if (p.id) playerLabel.set(p.id, p.number ? `${p.number} ${p.name}` : p.name);
+    });
+
+    const escapeXml = (s: string) =>
+      s
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&apos;");
+
+    // Sportscode uses 16-bit colour channels (0-65535).
+    const hexTo16 = (hex: string) => {
+      const m = /^#?([0-9a-fA-F]{6})$/.exec(hex || "");
+      if (!m) return { r: 32896, g: 32896, b: 32896 };
+      const ch = (i: number) => Math.round(parseInt(m[1].slice(i, i + 2), 16) * 257);
+      return { r: ch(0), g: ch(2), b: ch(4) };
+    };
+
+    const parseIds = (json: string): number[] => {
+      try {
+        const ids = JSON.parse(json);
+        return Array.isArray(ids) ? ids : [];
+      } catch {
+        return [];
+      }
+    };
+
+    const label = (group: string, text: string) =>
+      `      <label>\n        <group>${escapeXml(group)}</group>\n        <text>${escapeXml(text)}</text>\n      </label>`;
+
+    // one <row> per distinct code, in first-appearance order
+    const rowColors = new Map<string, { r: number; g: number; b: number }>();
+    const instances: string[] = [];
+    let id = 1;
+
+    for (const clip of clips) {
+      const catIds = parseIds(clip.categories);
+      const code = catIds.length ? categoryName.get(catIds[0]) || "Untagged" : "Untagged";
+      if (!rowColors.has(code)) {
+        const hex = catIds.length ? categoryColor.get(catIds[0]) || "" : "";
+        rowColors.set(code, hexTo16(hex));
+      }
+
+      const labels: string[] = [];
+      catIds.slice(1).forEach(cid => {
+        const n = categoryName.get(cid);
+        if (n) labels.push(label("Category", n));
+      });
+      parseIds(clip.players || "[]").forEach(pid => {
+        const p = playerLabel.get(pid);
+        if (p) labels.push(label("Player", p));
+      });
+      if (clip.quarter) labels.push(label("Quarter", clip.quarter));
+      if (clip.notes && clip.notes.trim()) labels.push(label("Note", clip.notes.trim()));
+
+      instances.push(
+        `    <instance>\n      <ID>${id}</ID>\n      <start>${clip.start_time.toFixed(2)}</start>\n      <end>${clip.end_time.toFixed(2)}</end>\n      <code>${escapeXml(code)}</code>${labels.length ? "\n" + labels.join("\n") : ""}\n    </instance>`
+      );
+      id++;
+    }
+
+    const rows = [...rowColors.entries()]
+      .map(
+        ([code, c]) =>
+          `    <row>\n      <code>${escapeXml(code)}</code>\n      <R>${c.r}</R>\n      <G>${c.g}</G>\n      <B>${c.b}</B>\n    </row>`
+      )
+      .join("\n");
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<file>\n  <ALL_INSTANCES>\n${instances.join("\n")}\n  </ALL_INSTANCES>\n  <ROWS>\n${rows}\n  </ROWS>\n</file>\n`;
+
+    fs.writeFileSync(result.filePath, xml, "utf-8");
+    return { filePath: result.filePath, count: clips.length };
+  } catch (error) {
+    console.error("Error exporting Sportscode XML:", error);
+    throw error;
+  }
+});
+
 // Save analysis session as JSON
 ipcMain.handle("save-session", async (_event, projectId: number) => {
   try {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -105,6 +105,7 @@ export interface ElectronAPI {
 
   // Export clips data
   exportClipsData: (projectId: number) => Promise<{ filePath: string; count: number } | null>;
+  exportClipsXml: (projectId: number) => Promise<{ filePath: string; count: number } | null>;
 
   // Session operations
   saveSession: (projectId: number) => Promise<{ filePath: string; success: boolean } | null>;
@@ -222,6 +223,8 @@ const electronAPI: ElectronAPI = {
   // Export clips data
   exportClipsData: (projectId: number) =>
     ipcRenderer.invoke("export-clips-data", projectId),
+  exportClipsXml: (projectId: number) =>
+    ipcRenderer.invoke("export-clips-xml", projectId),
 
   // Session operations
   saveSession: (projectId: number) =>

--- a/src/renderer/components/ClipLibrary.tsx
+++ b/src/renderer/components/ClipLibrary.tsx
@@ -20,6 +20,7 @@ import {
   faTable,
   faVideo as faVideoFile,
   faFloppyDisk,
+  faFileCode,
   faPlayCircle,
 } from "@fortawesome/free-solid-svg-icons";
 import styles from "../styles/ClipLibrary.module.css";
@@ -372,6 +373,23 @@ export const ClipLibrary: React.FC<ClipLibraryProps> = ({
     }
   };
 
+  const handleExportXml = async () => {
+    if (!currentProject) return;
+
+    try {
+      setIsExporting(true);
+      const result = await window.electronAPI.exportClipsXml(currentProject.id);
+      if (result) {
+        showSuccess(t("app.clips.exportDataSuccess", { count: result.count, path: result.filePath }));
+      }
+    } catch (error) {
+      console.error("Error exporting Sportscode XML:", error);
+      showError(t("app.clips.exportDataError"));
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   const handleSaveSession = async () => {
     if (!currentProject) return;
 
@@ -509,6 +527,18 @@ export const ClipLibrary: React.FC<ClipLibraryProps> = ({
                 >
                   <FontAwesomeIcon icon={faFloppyDisk} />
                   {t("app.clips.saveSession")}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={styles.exportMenuItem}
+                  onClick={() => {
+                    setExportMenuOpen(false);
+                    handleExportXml();
+                  }}
+                >
+                  <FontAwesomeIcon icon={faFileCode} />
+                  {t("app.clips.exportSportscode")}
                 </button>
               </div>
             )}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -127,6 +127,7 @@ export interface ElectronAPI {
 
   // Export clips data
   exportClipsData: (projectId: number) => Promise<{ filePath: string; count: number } | null>;
+  exportClipsXml: (projectId: number) => Promise<{ filePath: string; count: number } | null>;
 
   // Session operations
   saveSession: (projectId: number) => Promise<{ filePath: string; success: boolean } | null>;


### PR DESCRIPTION
## What & why

Lots of clubs have one Hudl/Sportscode seat. This exports the tag timeline in the XML interchange format those tools import, so a coach can tag film in this free tool and hand the timeline to whoever has the paid analysis software.

## Changes

- New `export-clips-xml` IPC handler that writes a Sportscode timeline XML: one `<instance>` per clip (first category as `<code>`, extra categories / players / quarter / notes as `<label>` groups), plus a `<ROWS>` block with one row per code and 16-bit category colors.
- `exportClipsXml` added to preload and the type surface.
- Fourth item in the ClipLibrary export menu ("Export Sportscode XML").
- `exportSportscode` string in all 11 locales ("Sportscode" left untranslated).

## Testing

`npm run build` passes. I validated the XML-building logic against a faithful replica with edge-case data (special characters, multi-category, players with/without numbers, untagged, bad hex color):
- `xmllint --noout` → well-formed.
- Escaping correct: `Pick &amp; Roll &lt;primary&gt;`, `7 O&apos;Brien`.
- Sequential IDs, first category as code with extras as labels, players as `number name`.
- `#4CAF50` → R19532/G44975/B20560 (16-bit). Bad hex and untagged fall back to gray 32896.
- One `<row>` per distinct code in first-appearance order.

The real handler wasn't driven through the Electron save dialog headlessly, and no real Sportscode import was tested — worth having someone with a seat validate one file before advertising the feature.

## Notes

- One-way export only (no XML import).
- Stacked on `feat/shot-chart` (#7). This is the top of the app stack — merge order: #3 → #4 → #5 → #6 → #7 → this.