### PR TITLE
fix: Present mode full screen, and rebuild the site on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,3 +202,12 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # The marketing site is a static Astro build that reads the latest release
+      # from the GitHub API at build time, so it advertises whatever version was
+      # current when it was last built. Ping its deploy hook so a release also
+      # refreshes the download button. Guarded: a repo without the secret skips
+      # this rather than failing the release over a website concern.
+      - name: Rebuild the marketing site
+        if: ${{ startsWith(github.ref, 'refs/tags/') && secrets.WEBSITE_DEPLOY_HOOK != '' }}
+        run: curl -fsS -X POST "${{ secrets.WEBSITE_DEPLOY_HOOK }}"

--- a/docs/design-audit-2026-09-07.md
+++ b/docs/design-audit-2026-09-07.md
@@ -1,0 +1,6 @@
+# Design audit, 2026-09-07
+
+The full audit covering both surfaces (this Electron app and the Astro
+marketing site) lives in the website repo at
+`website/docs/design-audit-2026-09-07.md`. Plans generated from it are in
+`plans/`, at the level above both repos.

--- a/src/renderer/components/PresentMode.tsx
+++ b/src/renderer/components/PresentMode.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -108,7 +109,10 @@ export const PresentMode: React.FC<PresentModeProps> = ({
     return null;
   }
 
-  return (
+  // The clip library sets container-type: inline-size, which makes it the
+  // containing block for fixed descendants. Portal to body so inset: 0
+  // resolves against the viewport instead of the side panel.
+  return createPortal(
     <div
       className={styles.presentMode}
       role="dialog"
@@ -202,6 +206,7 @@ export const PresentMode: React.FC<PresentModeProps> = ({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };


### PR DESCRIPTION
Batch A of the 2026-09-07 design audit, app side. Two commits, both small and
unrelated to each other except that they came from the same audit.
Report: `website/docs/design-audit-2026-09-07.md`. Plans: `plans/010`, `plans/013`.

## 1. Present mode covered 359px of the window instead of all of it

This is the feature the marketing site advertises by name, and the one a coach
uses standing in front of a team. What the room saw was a clip title truncated
to a single character and "Clip 1 of 8" wrapped over three lines.

The CSS was never wrong. `PresentMode` asks for `position: fixed; inset: 0;
z-index: 2500` and gets it. But `.clipLibrary` sets `container-type: inline-size`,
and an element with inline-size containment becomes the containing block for its
fixed descendants, the same way a `transform` does. `PresentMode` renders inside
that subtree, so `inset: 0` resolved against the side panel.

Portalling the overlay to `document.body` takes it out of the container without
touching the container query, which is load-bearing for the panel's responsive
layout (there is an `@supports not (container-type: inline-size)` fallback at
`ClipLibrary.module.css:850`).

Measured in a running build:

| | before | after |
|---|---|---|
| box at 1440x900 | `359 x 808` at `(1081, 76)` | `1440 x 900` at `(0, 0)` |
| box at 1024x700 | not full screen | `1024 x 700` at `(0, 0)` |
| clip title | truncated to `C…` | "Corner three off the weak-side flare", not truncated |
| counter | wrapped over 3 lines | "Clip 1 of 8", one line |

Escape still closes it, and ArrowLeft/ArrowRight still step between clips, which
was the one thing that could plausibly have broken.

## 2. The site advertises a build from two releases ago

The marketing site is a static Astro build that reads the latest release from
the GitHub API at build time. Nothing rebuilds it when a release ships, so it
has been showing **1.6.0** since that release while **v1.7.2** has been current
since 2026-07-13. Anyone downloading from the site gets the build from before
the Windows startup fix and before the auto-update repair, so they cannot even
update themselves out of it.

The release job now pings a deploy hook after publishing. It is the last step
and guarded on the secret, so a website problem can never fail a release, and a
fork without the secret skips it.

**This needs one thing from you**: create a Vercel deploy hook for the website
project and add it as a repo secret named `WEBSITE_DEPLOY_HOOK`. Until then the
step is inert and the site stays on 1.6.0. No URL is committed anywhere.

## Verification

`npm run build` passes. There is no test suite in this repo, so the Present mode
numbers above were measured by driving a real build through Playwright rather
than eyeballed. The workflow YAML parses and the new step is confirmed last in
the `release` job, with the `build` job untouched.