### PR TITLE
Give "act here" and "that worked" different greens

### DIFF
--- a/src/renderer/styles/CategoryManager.module.css
+++ b/src/renderer/styles/CategoryManager.module.css
@@ -241,7 +241,7 @@
 /* Improved subcategory form */
 .addSubcategoryForm {
   background: var(--bg-secondary);
-  border: 2px solid var(--color-success);
+  border: 2px solid var(--color-primary);
   border-radius: var(--radius-lg);
   padding: var(--spacing-lg);
   margin: var(--spacing-md) 0;
@@ -616,8 +616,8 @@
 .addSubBtn {
   height: 32px;
   width: 32px;
-  background: var(--color-success);
-  border: 1px solid var(--color-success);
+  background: var(--color-primary);
+  border: 1px solid var(--color-primary);
   color: var(--text-white);
   padding: 0;
   border-radius: var(--radius-md);

--- a/src/renderer/styles/ClipCreator.module.css
+++ b/src/renderer/styles/ClipCreator.module.css
@@ -337,8 +337,8 @@
 }
 
 .selectAllBtn:hover:not(:disabled) {
-  background: var(--color-success);
-  border-color: var(--color-success);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
   color: var(--text-primary);
   transform: translateY(-1px);
 }

--- a/src/renderer/styles/Toast.module.css
+++ b/src/renderer/styles/Toast.module.css
@@ -37,7 +37,7 @@
 }
 
 .toast.success {
-  background: rgba(76, 175, 80, 0.9);
+  background: rgba(var(--color-success-rgb), 0.9);
   color: var(--text-white);
   border-left: 4px solid var(--color-success-dark);
 }

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -110,7 +110,7 @@
 }
 
 .markIn {
-  background: var(--color-success);
+  background: var(--color-primary);
 }
 
 .markOut {
@@ -273,7 +273,7 @@
 }
 
 .markInBtn {
-  background: var(--color-success);
+  background: var(--color-primary);
   color: var(--text-white);
 }
 

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -8,8 +8,9 @@
   --color-danger: #f44336;
   --color-danger-dark: #d32f2f;
   --color-danger-light: #ef5350;
-  --color-success: #4caf50;
-  --color-success-dark: #388e3c;
+  --color-success: #2e7d32;
+  --color-success-rgb: 46, 125, 50;
+  --color-success-dark: #1b5e20;
   --color-warning: #ff9800;
   --color-info: #2196f3;
 
@@ -120,7 +121,9 @@
   --color-primary-dark: #1b5e20;
   --color-primary-light: #388e3c;
 
-  --color-success-dark: #1b5e20;
+  --color-success: #1b5e20;
+  --color-success-rgb: 27, 94, 32;
+  --color-success-dark: #14481a;
 
   /* Background Colors */
   --bg-main: #ffffff;


### PR DESCRIPTION
Plan 019. First of five in the Scorebook identity stack; merge bottom-up.

`--color-primary` and `--color-success` were both `#4caf50`, so the app could not tell a button apart from a confirmation. The light theme redefined primary but not success, which left anything on success inheriting the dark theme's value.

## Changes
- Success gets its own colour in both themes.
- Five rules used success for an *action* and move to primary. Mark In was one of them, so without this the accent could not have reached the control it exists for.
- The success toast's fill was a literal `rgba(76, 175, 80, 0.9)` outside the token system. It reads the token now.

## Correction to the plan
Plan 019 expected to find primary used for confirmations. The entanglement ran the other way: nothing used primary for a confirmation, and five rules used success for an action.

## Testing
`npm run build` green. White on the success toast goes 3.28:1 → 5.83:1 dark, 6.14:1 light. The other three toast fills are still literals and were left alone.