### PR TITLE
Move the app's action colour to the Scorebook teal

### DIFF
--- a/src/renderer/styles/PresentMode.module.css
+++ b/src/renderer/styles/PresentMode.module.css
@@ -80,7 +80,7 @@
   display: inline-block;
   font-family: var(--font-mono);
   font-size: var(--font-size-sm);
-  color: var(--color-primary-light);
+  color: var(--color-accent-on-dark);
   margin-bottom: 4px;
 }
 

--- a/src/renderer/styles/Telestration.module.css
+++ b/src/renderer/styles/Telestration.module.css
@@ -149,7 +149,7 @@
 }
 
 .saveBtn {
-  color: var(--color-primary-light);
+  color: var(--color-accent-on-dark);
 }
 
 .saveBtn:hover:not(:disabled) {

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -2,9 +2,15 @@
 :root,
 [data-theme="dark"] {
   /* Colors */
-  --color-primary: #4caf50;
-  --color-primary-dark: #45a049;
-  --color-primary-light: #66bb6a;
+  /* Teal is the one accent, and it has one job: the clip being cut right now.
+     It sits well clear of the orange band the category presets own, so "act
+     here" can never be read as "this is an offensive possession". */
+  --color-primary: #0a6e68;
+  --color-primary-dark: #075450;
+  --color-primary-light: #0f8f85;
+  /* The accent on a surface that is dark whatever the theme: Present mode and
+     the telestration toolbar both sit over video. */
+  --color-accent-on-dark: #3ed0c2;
   --color-danger: #f44336;
   --color-danger-dark: #d32f2f;
   --color-danger-light: #ef5350;
@@ -117,10 +123,8 @@
 /* Light theme */
 [data-theme="light"] {
   /* Colors */
-  --color-primary: #2e7d32;
-  --color-primary-dark: #1b5e20;
-  --color-primary-light: #388e3c;
-
+  /* The accent carries over from :root unchanged. White reads at 6.10:1 on it
+     in either theme, so the app and the site share one button colour. */
   --color-success: #1b5e20;
   --color-success-rgb: 27, 94, 32;
   --color-success-dark: #14481a;


### PR DESCRIPTION
Plan 018, app half. Stacked on #019's branch.

Option C from the accent plan, settled by the direction hunt: a third colour for actions, so neither surface's old accent wins and the category presets keep the orange band.

## The fork this hit
`--color-primary` does two jobs that pull opposite ways: a fill behind white text, and text on a dark ground. No single hex clears 4.5:1 both ways, the crossover is about 4.1:1.

So the fill keeps white labels and is the same in both themes, which means the app and the site share one button colour. The two places drawing the accent as text sit over video and are dark whatever the theme, so they get `--color-accent-on-dark` instead.

## Changes
- Accent fill and hover, one definition, both themes.
- `--color-accent-on-dark` for the Present mode counter and the telestration save button.
- The light theme no longer overrides the accent; it was carrying a second green for nothing.
- Category preset colours untouched. Those are identity, not decoration.

## Screenshots
| Dark | Light |
|---|---|
| [![dark](https://github.com/kauredo/basketball-video-analyzer/blob/pr-assets/scorebook-identity/app-dark.png?raw=true)](https://github.com/kauredo/basketball-video-analyzer/blob/pr-assets/scorebook-identity/app-dark.png?raw=true) | [![light](https://github.com/kauredo/basketball-video-analyzer/blob/pr-assets/scorebook-identity/app-light.png?raw=true)](https://github.com/kauredo/basketball-video-analyzer/blob/pr-assets/scorebook-identity/app-light.png?raw=true) |

## Testing
`npm run build` green. Ratios land in the following PR, which moves the fill once more to clear the graphite ground.