### PR TITLE
Declare the app's typefaces instead of inheriting the platform's

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "basketball-video-analyzer",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "basketball-video-analyzer",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+        "@fontsource-variable/space-grotesk": "^5.3.0",
+        "@fontsource/ibm-plex-mono": "^5.3.0",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
@@ -946,6 +949,33 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/@fontsource-variable/ibm-plex-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/ibm-plex-sans/-/ibm-plex-sans-5.3.0.tgz",
+      "integrity": "sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/space-grotesk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/space-grotesk/-/space-grotesk-5.3.0.tgz",
+      "integrity": "sha512-2IxmvfB08i9vnGB3Ym/AXvhRE+8XOjWMXIyDum03c+tPwH0FUoMNQfGpU8NXPxjbws0Vvss3AH0Zqt4oJBBAdw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.3.0.tgz",
+      "integrity": "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "webpack-cli": "^5.1.0"
   },
   "dependencies": {
+    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+    "@fontsource-variable/space-grotesk": "^5.3.0",
+    "@fontsource/ibm-plex-mono": "^5.3.0",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -8,8 +8,16 @@
   <style>
     body {
       margin: 0;
-      font-family:
-        -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", sans-serif;
+      /* This block paints before the bundle injects variables.css, so the
+         platform stack stands in for one frame. */
+      font-family: var(
+        --font-body,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        "Roboto",
+        sans-serif
+      );
       background: var(--bg-primary);
       color: var(--text-primary);
       overflow: hidden;

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -3,6 +3,12 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import { ToastProvider } from "./contexts/ToastContext";
 import { ConfirmProvider } from "./contexts/ConfirmContext";
+// Self-hosted: the app is offline software and must never reach a font CDN.
+import "@fontsource-variable/space-grotesk/wght.css";
+import "@fontsource-variable/ibm-plex-sans/wght.css";
+import "@fontsource/ibm-plex-mono/latin-400.css";
+import "@fontsource/ibm-plex-mono/latin-500.css";
+import "@fontsource/ibm-plex-mono/latin-600.css";
 import "./styles/variables.css";
 import "../i18n";
 

--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -26,6 +26,7 @@
 
 .title {
   color: var(--text-primary);
+  font-family: var(--font-display);
 }
 
 .mainContent {

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -116,8 +116,13 @@
   --focus-ring: 0 0 0 2px var(--color-primary-light);
   --focus-ring-within: 0 0 0 2px var(--color-primary);
 
-  /* Monospace Font */
-  --font-mono: "Monaco", "Menlo", "Ubuntu Mono", monospace;
+  /* Typefaces. Plex Sans carries interface text rather than Space Grotesk,
+     because Space Grotesk has no Greek and el.json needs it. Space Grotesk is
+     for display only. Every fallback stack is real, so a missing font file
+     degrades instead of breaking. */
+  --font-display: "Space Grotesk Variable", "Space Grotesk", system-ui, sans-serif;
+  --font-body: "IBM Plex Sans Variable", "IBM Plex Sans", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", "Monaco", "Menlo", "Ubuntu Mono", monospace;
 }
 
 /* Light theme */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,11 @@ module.exports = (env, argv) => {
           use: [{ loader: "ts-loader" }],
         },
         {
+          test: /\.woff2?$/,
+          type: "asset/resource",
+          generator: { filename: "fonts/[name][ext]" },
+        },
+        {
           test: /\.css$/,
           use: [
             "style-loader",


### PR DESCRIPTION
Plan 020. Stacked on #12.

The app shipped with no `font-family` of its own, so it rendered in SF Pro on macOS, Segoe UI on Windows and Roboto on Linux while the site used Space Grotesk. Windows is about half the downloads, and the gap was invisible to anyone testing on a Mac.

## Changes
- **IBM Plex Sans** for interface text, **IBM Plex Mono** for timecodes and key chips, **Space Grotesk** for the header wordmark only.
- Webpack had no rule for font files at all, so one was added.
- The inline `<style>` in `index.html` paints before the bundle injects the tokens, so it keeps the platform stack as an inline `var()` fallback.

## Correction to the plan
Plan 020 was written before the direction hunt and specified DM Sans. Plex Sans carries interface text instead: Space Grotesk has no Greek and `el.json` is the one locale of eleven that needs it. Plex Mono is also a sibling of Plex Sans, so the numbers and labels share proportion. There is no variable build of Plex Mono, so it is loaded at 400/500/600, which is what the modules using it ask for.

## Testing
Self-hosted, since the app is offline software and must not reach a font CDN. Verified in the running app that all three faces plus the Greek and Latin Extended subsets resolve over `file://`, and that all 15 woff/woff2 files are present in the packaged asar. Fonts cost 320KB on disk; the bundle grows 50KB.