### PR TITLE
Clear the app's remaining contrast failures

### DIFF
--- a/src/renderer/styles/FeedbackModal.module.css
+++ b/src/renderer/styles/FeedbackModal.module.css
@@ -116,7 +116,7 @@
 
 .charCount {
   font-size: var(--font-size-xs);
-  color: var(--text-muted);
+  color: var(--text-tertiary);
   text-align: right;
   margin-top: 2px;
 }
@@ -140,7 +140,7 @@
 
 .systemInfo {
   font-size: var(--font-size-xs);
-  color: var(--text-muted);
+  color: var(--text-tertiary);
   padding: var(--spacing-xs) 0;
 }
 

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -5,7 +5,7 @@
   /* Teal is the one accent, and it has one job: the clip being cut right now.
      It sits well clear of the orange band the category presets own, so "act
      here" can never be read as "this is an offensive possession". */
-  --color-primary: #0a6e68;
+  --color-primary: #0b7972;
   --color-primary-dark: #075450;
   --color-primary-light: #0f8f85;
   /* The accent on a surface that is dark whatever the theme: Present mode and


### PR DESCRIPTION
Plan 021, app half. Stacked on the typefaces branch.

Recomputed every token pair the app can render, in both themes, rather than reusing the audit's table.

## What the accent work had already fixed
| Pair | Before | After |
|---|---|---|
| White on Export Clips and filter chips | 2.78:1 | 5.26:1 |
| White on Mark In (Z) | 2.78:1 | 5.26:1 |
| White on the success toast, dark | 3.28:1 | 5.83:1 |

## What the sweep found that the audit's table did not
- The accent read **2.85:1 against the app's own graphite ground**, under the 3.0 bar for identifying a control, so the button shape was hard to pick out even though its label was fine. The fill moves to `#0b7972`, which is inside the window clearing both: 3.31:1 on graphite, 5.26:1 on paper, white labels 5.26:1.
- `.charCount` and `.systemInfo` drew 12px text in `--text-muted`, an icon colour at the 3.0 bar, measuring 3.03:1 dark and 2.68:1 light. They use `--text-tertiary` now.

## Corrections to the audit
Mark In was reported at 2.36:1 on `--color-primary-light`. It was actually on `--color-success`, and `--color-primary-light` is never used as a fill.

## Not fixed
White on the danger, warning and info fills still fails at 3.68:1, 2.16:1 and 3.12:1. Out of this plan's scope and not yet planned.