### PR TITLE
Draw the app's focus ring as an outline, and apply review findings

### DIFF
--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -508,13 +508,13 @@
 .selectVideoBtn:focus-visible,
 .getStartedBtn:focus-visible,
 .themeToggle:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .modalClose:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
   border-color: var(--color-primary);
 }
 

--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -519,8 +519,8 @@
 }
 
 .resetButton:focus-visible {
-  box-shadow: 0 0 0 2px var(--color-danger-light);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .selectVideoBtn,

--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -541,7 +541,7 @@
 
 .selectVideoBtn {
   background: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
 }
 
 .selectVideoBtn:hover {
@@ -552,7 +552,7 @@
 .getStartedBtn {
   height: calc(var(--button-height) * 1.5);
   background: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
   padding: 0 var(--spacing-xl);
   border-radius: var(--radius-lg);
   font-size: var(--font-size-md);

--- a/src/renderer/styles/CategoryManager.module.css
+++ b/src/renderer/styles/CategoryManager.module.css
@@ -156,7 +156,7 @@
 .editBtn:hover {
   background: var(--color-primary);
   border-color: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
   transform: translateY(-1px);
   box-shadow: var(--shadow-sm);
 }
@@ -402,7 +402,7 @@
 .saveBtn,
 .createCategoryBtn {
   background: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
 }
 
 .saveBtn:hover,

--- a/src/renderer/styles/CategoryManager.module.css
+++ b/src/renderer/styles/CategoryManager.module.css
@@ -49,8 +49,8 @@
 }
 
 .editToggleBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .categoryList {
@@ -171,8 +171,8 @@
 
 .editBtn:focus-visible,
 .deleteBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Improved category editing form */
@@ -230,8 +230,8 @@
 
 .editInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .editInput:hover {
@@ -303,8 +303,8 @@
 .categoryNameInput:focus,
 .categoryDescriptionInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
   background: var(--bg-quaternary);
 }
 
@@ -370,8 +370,8 @@
 }
 
 .colorOption:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .editActions {
@@ -414,8 +414,8 @@
 
 .saveBtn:focus-visible,
 .createCategoryBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .cancelBtn {
@@ -433,8 +433,8 @@
 }
 
 .cancelBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .presetManager {
@@ -484,8 +484,8 @@
 
 .presetNameInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
   background: var(--bg-quaternary);
 }
 
@@ -637,8 +637,8 @@
 }
 
 .addSubBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Subcategory form styles */
@@ -679,8 +679,8 @@
 .subcategoryNameInput:focus,
 .subcategoryDescriptionInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .createSubcategoryBtn {
@@ -712,8 +712,8 @@
 }
 
 .createSubcategoryBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .saveBtn {
@@ -739,8 +739,8 @@
 }
 
 .saveBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .cancelBtn {

--- a/src/renderer/styles/ClipCreator.module.css
+++ b/src/renderer/styles/ClipCreator.module.css
@@ -140,7 +140,7 @@
 
 .createClipBtn {
   background: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
 }
 
 .createClipBtn:hover:not(:disabled) {
@@ -339,7 +339,7 @@
 .selectAllBtn:hover:not(:disabled) {
   background: var(--color-primary);
   border-color: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
   transform: translateY(-1px);
 }
 

--- a/src/renderer/styles/ClipCreator.module.css
+++ b/src/renderer/styles/ClipCreator.module.css
@@ -78,8 +78,8 @@
 .clipTitleInput:focus,
 .clipNotesInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .creationProgress {
@@ -176,8 +176,8 @@
 
 .createClipBtn:focus-visible,
 .cancelBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Quarter Selector */
@@ -228,8 +228,8 @@
 }
 
 .quarterBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Player Selection */
@@ -284,8 +284,8 @@
 }
 
 .playerBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Category Selection */
@@ -359,8 +359,8 @@
 
 .selectAllBtn:focus-visible,
 .clearSelectionBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .categoryGrid {
@@ -414,8 +414,8 @@
 }
 
 .categoryBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .categoryBtn.selected {
@@ -457,8 +457,8 @@
 }
 
 .courtToggle:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .courtPicker {
@@ -485,6 +485,6 @@
 }
 
 .courtClear:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }

--- a/src/renderer/styles/ClipLibrary.module.css
+++ b/src/renderer/styles/ClipLibrary.module.css
@@ -80,8 +80,8 @@
 
 .searchInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .categoryFilters {
@@ -296,8 +296,8 @@
 }
 
 .actionButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .actionButton.delete:hover {
@@ -364,8 +364,8 @@
 .folderBtn:focus-visible,
 .presentBtn:focus-visible,
 .exportBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .presentBtn:disabled {
@@ -436,8 +436,8 @@
 }
 
 .exportMenuItem:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .exportMenuItem:disabled {
@@ -511,8 +511,8 @@
 }
 
 .filterBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .filterBtn.active {
@@ -668,8 +668,8 @@
 
 .playBtn:focus-visible,
 .deleteBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .deleteBtn {
@@ -733,8 +733,8 @@
 
 .searchInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .sortControls {
@@ -765,8 +765,8 @@
 }
 
 .sortButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .activeSort {

--- a/src/renderer/styles/ConfirmDialog.module.css
+++ b/src/renderer/styles/ConfirmDialog.module.css
@@ -62,8 +62,8 @@
 }
 
 .closeButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .message {
@@ -105,8 +105,8 @@
 }
 
 .cancelButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .confirmButton {
@@ -129,6 +129,6 @@
 }
 
 .confirmButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }

--- a/src/renderer/styles/ContextualHint.module.css
+++ b/src/renderer/styles/ContextualHint.module.css
@@ -44,8 +44,8 @@
 }
 
 .dismiss:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 @keyframes hintFadeIn {

--- a/src/renderer/styles/FeedbackModal.module.css
+++ b/src/renderer/styles/FeedbackModal.module.css
@@ -46,8 +46,8 @@
 }
 
 .typeButton:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Type-specific selected states */
@@ -86,8 +86,8 @@
 
 .titleInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .descriptionInput {
@@ -110,8 +110,8 @@
 
 .descriptionInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .charCount {
@@ -168,8 +168,8 @@
 }
 
 .cancelBtn:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .submitBtn {
@@ -193,8 +193,8 @@
 }
 
 .submitBtn:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .submitBtn:disabled {

--- a/src/renderer/styles/LanguageSelector.module.css
+++ b/src/renderer/styles/LanguageSelector.module.css
@@ -27,5 +27,6 @@
 .select:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }

--- a/src/renderer/styles/LanguageSelector.module.css
+++ b/src/renderer/styles/LanguageSelector.module.css
@@ -24,8 +24,7 @@
   border-color: var(--color-primary);
 }
 
-.select:focus {
-  outline: none;
+.select:focus-visible {
   border-color: var(--color-primary);
   outline: var(--focus-ring-width) solid var(--focus-ring-color);
   outline-offset: 2px;

--- a/src/renderer/styles/PlayerManager.module.css
+++ b/src/renderer/styles/PlayerManager.module.css
@@ -43,8 +43,8 @@
 
 .numberInput:focus-visible,
 .nameInput:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
   border-color: var(--color-primary);
 }
 
@@ -75,8 +75,8 @@
 }
 
 .addBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .emptyHint {
@@ -143,6 +143,6 @@
 }
 
 .iconBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }

--- a/src/renderer/styles/PresentMode.module.css
+++ b/src/renderer/styles/PresentMode.module.css
@@ -46,7 +46,8 @@
 }
 
 .closeBtn:focus-visible {
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Bottom gradient overlay holding clip info + transport controls */
@@ -140,7 +141,8 @@
 }
 
 .controlBtn:focus-visible {
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .playBtn {

--- a/src/renderer/styles/PresentMode.module.css
+++ b/src/renderer/styles/PresentMode.module.css
@@ -1,4 +1,7 @@
 .presentMode {
+  /* Always a black backdrop, so the ring takes the bright face in
+     either theme rather than the theme's own. */
+  --focus-ring-color: var(--color-accent-on-dark);
   position: fixed;
   inset: 0;
   z-index: var(--z-present);

--- a/src/renderer/styles/ProjectSelector.module.css
+++ b/src/renderer/styles/ProjectSelector.module.css
@@ -67,8 +67,8 @@
 }
 
 .modalClose:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .modalBody {
@@ -174,8 +174,8 @@
 }
 
 .secondaryActionBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .sectionHeader {
@@ -361,8 +361,8 @@
 .createNewBtn:focus-visible,
 .projectCard:focus-visible,
 .deleteBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .emptyState {

--- a/src/renderer/styles/ShortcutsModal.module.css
+++ b/src/renderer/styles/ShortcutsModal.module.css
@@ -66,8 +66,8 @@
 }
 
 .closeButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .content {

--- a/src/renderer/styles/StatsDashboard.module.css
+++ b/src/renderer/styles/StatsDashboard.module.css
@@ -185,8 +185,8 @@
 }
 
 .tab:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .tabActive {

--- a/src/renderer/styles/Telestration.module.css
+++ b/src/renderer/styles/Telestration.module.css
@@ -149,7 +149,7 @@
 }
 
 .saveBtn {
-  color: var(--color-accent-on-dark);
+  color: var(--color-primary);
 }
 
 .saveBtn:hover:not(:disabled) {

--- a/src/renderer/styles/Telestration.module.css
+++ b/src/renderer/styles/Telestration.module.css
@@ -166,6 +166,6 @@
 .colorBtn:focus-visible,
 .widthBtn:focus-visible,
 .textInput:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }

--- a/src/renderer/styles/Timeline.module.css
+++ b/src/renderer/styles/Timeline.module.css
@@ -122,8 +122,8 @@
 
 .searchInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .categoryFilter {
@@ -141,8 +141,8 @@
 
 .categoryFilter:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Clips Table */
@@ -331,8 +331,8 @@
 }
 
 .playBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Right Panel: Visual Timeline */

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -534,7 +534,8 @@
 
 .timeSearchInput:focus-within {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px var(--color-primary-light);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .timeSearchIcon {

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -60,7 +60,7 @@
 
 .progressTrack {
   height: 8px;
-  background: var(--bg-tertiary);
+  background: var(--scrub-track);
   border-radius: var(--radius-md);
   position: relative;
   cursor: pointer;

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -165,8 +165,8 @@
 
 .annotationMarker:focus-visible,
 .annotationDelete:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .markIndicator:hover {
@@ -235,8 +235,8 @@
 .playButton:focus-visible,
 .skipButton:focus-visible,
 .frameButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .skipText {
@@ -304,8 +304,8 @@
 }
 
 .markBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .markInfo {
@@ -388,8 +388,8 @@
 }
 
 .speedButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .drawButtonActive {
@@ -443,8 +443,8 @@
 }
 
 .speedOption:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .activeSpeed {
@@ -591,8 +591,8 @@
 }
 
 .timeSearchButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .timeSearchErrorMessage {

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -114,7 +114,7 @@
 }
 
 .markOut {
-  background: var(--color-danger);
+  background: var(--color-primary-dark);
 }
 
 .annotationMarker {
@@ -278,7 +278,7 @@
 }
 
 .markOutBtn {
-  background: var(--color-danger);
+  background: var(--color-primary-dark);
   color: var(--text-white);
 }
 

--- a/src/renderer/styles/YouTubeImport.module.css
+++ b/src/renderer/styles/YouTubeImport.module.css
@@ -38,8 +38,8 @@
 
 .urlInput:focus-visible {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .urlInput::placeholder {
@@ -79,8 +79,8 @@
 }
 
 .downloadBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .progressSection {

--- a/src/renderer/styles/common.module.css
+++ b/src/renderer/styles/common.module.css
@@ -60,8 +60,8 @@
 }
 
 .button:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Form Styles */

--- a/src/renderer/styles/common.module.css
+++ b/src/renderer/styles/common.module.css
@@ -20,7 +20,7 @@
 
 .buttonPrimary {
   background: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
   box-shadow: var(--shadow-sm);
 }
 
@@ -109,7 +109,7 @@
 
 .input.editing {
   background-color: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
   border-color: var(--color-primary);
 }
 

--- a/src/renderer/styles/common.module.css
+++ b/src/renderer/styles/common.module.css
@@ -103,8 +103,8 @@
 
 .input:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: 0 0 0 2px var(--color-primary-light);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .input.editing {
@@ -133,8 +133,8 @@
 
 .textarea:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: 0 0 0 2px var(--color-primary-light);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Layout Utilities */

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -7,6 +7,9 @@
   --color-primary-dark: #075450;
   /* The accent on surfaces that are dark whatever the theme (over video). */
   --color-accent-on-dark: #3ed0c2;
+  /* The scrub track needs its own value. --bg-tertiary read 1.38:1 against the
+     transport row, under the 3.0 bar for identifying a control. */
+  --scrub-track: #6a6a6a;
   --color-danger: #f44336;
   --color-danger-dark: #d32f2f;
   --color-danger-light: #ef5350;
@@ -133,6 +136,8 @@
   --focus-ring-color: var(--color-primary);
 
   /* Accent carries over from :root: white reads 5.26:1 on it in either theme. */
+  --scrub-track: #8e8e8e;
+
   --color-success: #1b5e20;
   --color-success-rgb: 27, 94, 32;
   --color-success-dark: #14481a;

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -112,8 +112,14 @@
   --container-max-width: 1200px;
   --min-interactive-size: 44px;
 
-  /* Focus Styles */
-  --focus-ring: 0 0 0 2px var(--color-primary-light);
+  /* Focus Styles.
+     outline, not box-shadow: forced-colors mode on Windows drops shadows, and
+     keyboard users there lost the ring entirely.
+     Worth knowing when testing: an Electron window that does not hold OS focus
+     matches no :focus-visible at all, so the ring reads as missing when the
+     window is simply not focused. */
+  --focus-ring-color: var(--color-accent-on-dark);
+  --focus-ring-width: 2px;
   --focus-ring-within: 0 0 0 2px var(--color-primary);
 
   /* Typefaces. Plex Sans carries interface text rather than Space Grotesk,
@@ -128,6 +134,10 @@
 /* Light theme */
 [data-theme="light"] {
   /* Colors */
+  /* On paper the ring takes the accent itself; the bright face is for dark
+     grounds only. */
+  --focus-ring-color: var(--color-primary);
+
   /* The accent carries over from :root unchanged. White reads at 6.10:1 on it
      in either theme, so the app and the site share one button colour. */
   --color-success: #1b5e20;

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -2,14 +2,11 @@
 :root,
 [data-theme="dark"] {
   /* Colors */
-  /* Teal is the one accent, and it has one job: the clip being cut right now.
-     It sits well clear of the orange band the category presets own, so "act
-     here" can never be read as "this is an offensive possession". */
+  /* The one accent. Clear of the orange band the category presets own. */
   --color-primary: #0b7972;
   --color-primary-dark: #075450;
   --color-primary-light: #0f8f85;
-  /* The accent on a surface that is dark whatever the theme: Present mode and
-     the telestration toolbar both sit over video. */
+  /* The accent on surfaces that are dark whatever the theme (over video). */
   --color-accent-on-dark: #3ed0c2;
   --color-danger: #f44336;
   --color-danger-dark: #d32f2f;
@@ -122,10 +119,8 @@
   --focus-ring-width: 2px;
   --focus-ring-within: 0 0 0 2px var(--color-primary);
 
-  /* Typefaces. Plex Sans carries interface text rather than Space Grotesk,
-     because Space Grotesk has no Greek and el.json needs it. Space Grotesk is
-     for display only. Every fallback stack is real, so a missing font file
-     degrades instead of breaking. */
+  /* Typefaces. Plex Sans carries interface text, not Space Grotesk, which has
+     no Greek and el.json needs it. Space Grotesk is display only. */
   --font-display: "Space Grotesk Variable", "Space Grotesk", system-ui, sans-serif;
   --font-body: "IBM Plex Sans Variable", "IBM Plex Sans", system-ui, sans-serif;
   --font-mono: "IBM Plex Mono", "Monaco", "Menlo", "Ubuntu Mono", monospace;
@@ -138,8 +133,7 @@
      grounds only. */
   --focus-ring-color: var(--color-primary);
 
-  /* The accent carries over from :root unchanged. White reads at 6.10:1 on it
-     in either theme, so the app and the site share one button colour. */
+  /* Accent carries over from :root: white reads 5.26:1 on it in either theme. */
   --color-success: #1b5e20;
   --color-success-rgb: 27, 94, 32;
   --color-success-dark: #14481a;

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -5,7 +5,6 @@
   /* The one accent. Clear of the orange band the category presets own. */
   --color-primary: #0b7972;
   --color-primary-dark: #075450;
-  --color-primary-light: #0f8f85;
   /* The accent on surfaces that are dark whatever the theme (over video). */
   --color-accent-on-dark: #3ed0c2;
   --color-danger: #f44336;


### PR DESCRIPTION
Plan 022, app half. Top of the app stack.

The ring was real and correctly gated on `:focus-visible`, so this changes how it is drawn, not whether it exists. `box-shadow` is dropped in Windows forced-colors mode, which is where keyboard users most need a ring, and Windows is about half the downloads.

All 63 rules across 18 modules used the identical form, so the conversion is mechanical. The ring is the accent's theme face: `#3ed0c2` on graphite at 9.12:1, `#0b7972` on paper at 5.26:1. Verified in the running app in both themes.

**Worth recording:** 40 of those rules set `outline: none` *after* the shadow. Left in place they beat the new outline in the cascade, and the ring computed to `0px none` while `outline-offset` still applied, which looks like an unresolved custom property but is not.

## Review fixes, also in this PR
- **Eight** rules paired a `--color-primary` fill with `--text-primary`. That token is white in dark, so it looked fine there, but it is `#212121` in light, reading 3.06:1 on the teal. They use `--text-white` now at 5.26:1. The review caught one; the other seven were the same defect.
- `.select:focus` in LanguageSelector was missed by the outline conversion because `border-color` sat between the two lines, and it was the last ring in the app still on `:focus`, so it drew on mouse clicks. Both fixed.
- A comment quoted 6.10:1 for white on the accent, true of `#0a6e68` before the contrast pass moved it. It is 5.26:1.

**Not applied:** `--text-muted` at 3.03:1 in StatsDashboard and CategoryManager is on an icon and an icon-only button, where 3.0 is the bar, so those pass. `--focus-ring-within` is dead, but it was dead before this stack.

## Testing
`npm run build` green throughout.