### PR TITLE
Batch C, remainder: accent, typefaces, contrast, focus ring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "basketball-video-analyzer",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "basketball-video-analyzer",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+        "@fontsource-variable/space-grotesk": "^5.3.0",
+        "@fontsource/ibm-plex-mono": "^5.3.0",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
@@ -946,6 +949,33 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/@fontsource-variable/ibm-plex-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/ibm-plex-sans/-/ibm-plex-sans-5.3.0.tgz",
+      "integrity": "sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/space-grotesk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/space-grotesk/-/space-grotesk-5.3.0.tgz",
+      "integrity": "sha512-2IxmvfB08i9vnGB3Ym/AXvhRE+8XOjWMXIyDum03c+tPwH0FUoMNQfGpU8NXPxjbws0Vvss3AH0Zqt4oJBBAdw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.3.0.tgz",
+      "integrity": "sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "webpack-cli": "^5.1.0"
   },
   "dependencies": {
+    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
+    "@fontsource-variable/space-grotesk": "^5.3.0",
+    "@fontsource/ibm-plex-mono": "^5.3.0",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -8,8 +8,16 @@
   <style>
     body {
       margin: 0;
-      font-family:
-        -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", sans-serif;
+      /* This block paints before the bundle injects variables.css, so the
+         platform stack stands in for one frame. */
+      font-family: var(
+        --font-body,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        "Roboto",
+        sans-serif
+      );
       background: var(--bg-primary);
       color: var(--text-primary);
       overflow: hidden;

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -3,6 +3,12 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import { ToastProvider } from "./contexts/ToastContext";
 import { ConfirmProvider } from "./contexts/ConfirmContext";
+// Self-hosted: the app is offline software and must never reach a font CDN.
+import "@fontsource-variable/space-grotesk/wght.css";
+import "@fontsource-variable/ibm-plex-sans/wght.css";
+import "@fontsource/ibm-plex-mono/latin-400.css";
+import "@fontsource/ibm-plex-mono/latin-500.css";
+import "@fontsource/ibm-plex-mono/latin-600.css";
 import "./styles/variables.css";
 import "../i18n";
 

--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -508,13 +508,13 @@
 .selectVideoBtn:focus-visible,
 .getStartedBtn:focus-visible,
 .themeToggle:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .modalClose:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
   border-color: var(--color-primary);
 }
 

--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -519,8 +519,8 @@
 }
 
 .resetButton:focus-visible {
-  box-shadow: 0 0 0 2px var(--color-danger-light);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .selectVideoBtn,

--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -26,6 +26,7 @@
 
 .title {
   color: var(--text-primary);
+  font-family: var(--font-display);
 }
 
 .mainContent {

--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -541,7 +541,7 @@
 
 .selectVideoBtn {
   background: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
 }
 
 .selectVideoBtn:hover {
@@ -552,7 +552,7 @@
 .getStartedBtn {
   height: calc(var(--button-height) * 1.5);
   background: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
   padding: 0 var(--spacing-xl);
   border-radius: var(--radius-lg);
   font-size: var(--font-size-md);

--- a/src/renderer/styles/CategoryManager.module.css
+++ b/src/renderer/styles/CategoryManager.module.css
@@ -156,7 +156,7 @@
 .editBtn:hover {
   background: var(--color-primary);
   border-color: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
   transform: translateY(-1px);
   box-shadow: var(--shadow-sm);
 }
@@ -402,7 +402,7 @@
 .saveBtn,
 .createCategoryBtn {
   background: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
 }
 
 .saveBtn:hover,

--- a/src/renderer/styles/CategoryManager.module.css
+++ b/src/renderer/styles/CategoryManager.module.css
@@ -49,8 +49,8 @@
 }
 
 .editToggleBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .categoryList {
@@ -171,8 +171,8 @@
 
 .editBtn:focus-visible,
 .deleteBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Improved category editing form */
@@ -230,8 +230,8 @@
 
 .editInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .editInput:hover {
@@ -303,8 +303,8 @@
 .categoryNameInput:focus,
 .categoryDescriptionInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
   background: var(--bg-quaternary);
 }
 
@@ -370,8 +370,8 @@
 }
 
 .colorOption:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .editActions {
@@ -414,8 +414,8 @@
 
 .saveBtn:focus-visible,
 .createCategoryBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .cancelBtn {
@@ -433,8 +433,8 @@
 }
 
 .cancelBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .presetManager {
@@ -484,8 +484,8 @@
 
 .presetNameInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
   background: var(--bg-quaternary);
 }
 
@@ -637,8 +637,8 @@
 }
 
 .addSubBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Subcategory form styles */
@@ -679,8 +679,8 @@
 .subcategoryNameInput:focus,
 .subcategoryDescriptionInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .createSubcategoryBtn {
@@ -712,8 +712,8 @@
 }
 
 .createSubcategoryBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .saveBtn {
@@ -739,8 +739,8 @@
 }
 
 .saveBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .cancelBtn {

--- a/src/renderer/styles/ClipCreator.module.css
+++ b/src/renderer/styles/ClipCreator.module.css
@@ -140,7 +140,7 @@
 
 .createClipBtn {
   background: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
 }
 
 .createClipBtn:hover:not(:disabled) {
@@ -339,7 +339,7 @@
 .selectAllBtn:hover:not(:disabled) {
   background: var(--color-primary);
   border-color: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
   transform: translateY(-1px);
 }
 

--- a/src/renderer/styles/ClipCreator.module.css
+++ b/src/renderer/styles/ClipCreator.module.css
@@ -78,8 +78,8 @@
 .clipTitleInput:focus,
 .clipNotesInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .creationProgress {
@@ -176,8 +176,8 @@
 
 .createClipBtn:focus-visible,
 .cancelBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Quarter Selector */
@@ -228,8 +228,8 @@
 }
 
 .quarterBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Player Selection */
@@ -284,8 +284,8 @@
 }
 
 .playerBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Category Selection */
@@ -359,8 +359,8 @@
 
 .selectAllBtn:focus-visible,
 .clearSelectionBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .categoryGrid {
@@ -414,8 +414,8 @@
 }
 
 .categoryBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .categoryBtn.selected {
@@ -457,8 +457,8 @@
 }
 
 .courtToggle:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .courtPicker {
@@ -485,6 +485,6 @@
 }
 
 .courtClear:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }

--- a/src/renderer/styles/ClipLibrary.module.css
+++ b/src/renderer/styles/ClipLibrary.module.css
@@ -80,8 +80,8 @@
 
 .searchInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .categoryFilters {
@@ -296,8 +296,8 @@
 }
 
 .actionButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .actionButton.delete:hover {
@@ -364,8 +364,8 @@
 .folderBtn:focus-visible,
 .presentBtn:focus-visible,
 .exportBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .presentBtn:disabled {
@@ -436,8 +436,8 @@
 }
 
 .exportMenuItem:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .exportMenuItem:disabled {
@@ -511,8 +511,8 @@
 }
 
 .filterBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .filterBtn.active {
@@ -668,8 +668,8 @@
 
 .playBtn:focus-visible,
 .deleteBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .deleteBtn {
@@ -733,8 +733,8 @@
 
 .searchInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .sortControls {
@@ -765,8 +765,8 @@
 }
 
 .sortButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .activeSort {

--- a/src/renderer/styles/ConfirmDialog.module.css
+++ b/src/renderer/styles/ConfirmDialog.module.css
@@ -62,8 +62,8 @@
 }
 
 .closeButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .message {
@@ -105,8 +105,8 @@
 }
 
 .cancelButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .confirmButton {
@@ -129,6 +129,6 @@
 }
 
 .confirmButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }

--- a/src/renderer/styles/ContextualHint.module.css
+++ b/src/renderer/styles/ContextualHint.module.css
@@ -44,8 +44,8 @@
 }
 
 .dismiss:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 @keyframes hintFadeIn {

--- a/src/renderer/styles/FeedbackModal.module.css
+++ b/src/renderer/styles/FeedbackModal.module.css
@@ -116,7 +116,7 @@
 
 .charCount {
   font-size: var(--font-size-xs);
-  color: var(--text-muted);
+  color: var(--text-tertiary);
   text-align: right;
   margin-top: 2px;
 }
@@ -140,7 +140,7 @@
 
 .systemInfo {
   font-size: var(--font-size-xs);
-  color: var(--text-muted);
+  color: var(--text-tertiary);
   padding: var(--spacing-xs) 0;
 }
 

--- a/src/renderer/styles/FeedbackModal.module.css
+++ b/src/renderer/styles/FeedbackModal.module.css
@@ -46,8 +46,8 @@
 }
 
 .typeButton:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Type-specific selected states */
@@ -86,8 +86,8 @@
 
 .titleInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .descriptionInput {
@@ -110,8 +110,8 @@
 
 .descriptionInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .charCount {
@@ -168,8 +168,8 @@
 }
 
 .cancelBtn:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .submitBtn {
@@ -193,8 +193,8 @@
 }
 
 .submitBtn:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .submitBtn:disabled {

--- a/src/renderer/styles/LanguageSelector.module.css
+++ b/src/renderer/styles/LanguageSelector.module.css
@@ -27,5 +27,6 @@
 .select:focus {
   outline: none;
   border-color: var(--color-primary);
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }

--- a/src/renderer/styles/LanguageSelector.module.css
+++ b/src/renderer/styles/LanguageSelector.module.css
@@ -24,8 +24,7 @@
   border-color: var(--color-primary);
 }
 
-.select:focus {
-  outline: none;
+.select:focus-visible {
   border-color: var(--color-primary);
   outline: var(--focus-ring-width) solid var(--focus-ring-color);
   outline-offset: 2px;

--- a/src/renderer/styles/PlayerManager.module.css
+++ b/src/renderer/styles/PlayerManager.module.css
@@ -43,8 +43,8 @@
 
 .numberInput:focus-visible,
 .nameInput:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
   border-color: var(--color-primary);
 }
 
@@ -75,8 +75,8 @@
 }
 
 .addBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .emptyHint {
@@ -143,6 +143,6 @@
 }
 
 .iconBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }

--- a/src/renderer/styles/PresentMode.module.css
+++ b/src/renderer/styles/PresentMode.module.css
@@ -80,7 +80,7 @@
   display: inline-block;
   font-family: var(--font-mono);
   font-size: var(--font-size-sm);
-  color: var(--color-primary-light);
+  color: var(--color-accent-on-dark);
   margin-bottom: 4px;
 }
 

--- a/src/renderer/styles/PresentMode.module.css
+++ b/src/renderer/styles/PresentMode.module.css
@@ -46,7 +46,8 @@
 }
 
 .closeBtn:focus-visible {
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Bottom gradient overlay holding clip info + transport controls */
@@ -140,7 +141,8 @@
 }
 
 .controlBtn:focus-visible {
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .playBtn {

--- a/src/renderer/styles/PresentMode.module.css
+++ b/src/renderer/styles/PresentMode.module.css
@@ -1,4 +1,7 @@
 .presentMode {
+  /* Always a black backdrop, so the ring takes the bright face in
+     either theme rather than the theme's own. */
+  --focus-ring-color: var(--color-accent-on-dark);
   position: fixed;
   inset: 0;
   z-index: var(--z-present);

--- a/src/renderer/styles/ProjectSelector.module.css
+++ b/src/renderer/styles/ProjectSelector.module.css
@@ -67,8 +67,8 @@
 }
 
 .modalClose:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .modalBody {
@@ -174,8 +174,8 @@
 }
 
 .secondaryActionBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .sectionHeader {
@@ -361,8 +361,8 @@
 .createNewBtn:focus-visible,
 .projectCard:focus-visible,
 .deleteBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .emptyState {

--- a/src/renderer/styles/ShortcutsModal.module.css
+++ b/src/renderer/styles/ShortcutsModal.module.css
@@ -66,8 +66,8 @@
 }
 
 .closeButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .content {

--- a/src/renderer/styles/StatsDashboard.module.css
+++ b/src/renderer/styles/StatsDashboard.module.css
@@ -185,8 +185,8 @@
 }
 
 .tab:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .tabActive {

--- a/src/renderer/styles/Telestration.module.css
+++ b/src/renderer/styles/Telestration.module.css
@@ -149,7 +149,7 @@
 }
 
 .saveBtn {
-  color: var(--color-accent-on-dark);
+  color: var(--color-primary);
 }
 
 .saveBtn:hover:not(:disabled) {

--- a/src/renderer/styles/Telestration.module.css
+++ b/src/renderer/styles/Telestration.module.css
@@ -149,7 +149,7 @@
 }
 
 .saveBtn {
-  color: var(--color-primary-light);
+  color: var(--color-accent-on-dark);
 }
 
 .saveBtn:hover:not(:disabled) {

--- a/src/renderer/styles/Telestration.module.css
+++ b/src/renderer/styles/Telestration.module.css
@@ -166,6 +166,6 @@
 .colorBtn:focus-visible,
 .widthBtn:focus-visible,
 .textInput:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }

--- a/src/renderer/styles/Timeline.module.css
+++ b/src/renderer/styles/Timeline.module.css
@@ -122,8 +122,8 @@
 
 .searchInput:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .categoryFilter {
@@ -141,8 +141,8 @@
 
 .categoryFilter:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Clips Table */
@@ -331,8 +331,8 @@
 }
 
 .playBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Right Panel: Visual Timeline */

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -534,7 +534,8 @@
 
 .timeSearchInput:focus-within {
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px var(--color-primary-light);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .timeSearchIcon {

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -60,7 +60,7 @@
 
 .progressTrack {
   height: 8px;
-  background: var(--bg-tertiary);
+  background: var(--scrub-track);
   border-radius: var(--radius-md);
   position: relative;
   cursor: pointer;

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -165,8 +165,8 @@
 
 .annotationMarker:focus-visible,
 .annotationDelete:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .markIndicator:hover {
@@ -235,8 +235,8 @@
 .playButton:focus-visible,
 .skipButton:focus-visible,
 .frameButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .skipText {
@@ -304,8 +304,8 @@
 }
 
 .markBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .markInfo {
@@ -388,8 +388,8 @@
 }
 
 .speedButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .drawButtonActive {
@@ -443,8 +443,8 @@
 }
 
 .speedOption:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .activeSpeed {
@@ -591,8 +591,8 @@
 }
 
 .timeSearchButton:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .timeSearchErrorMessage {

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -114,7 +114,7 @@
 }
 
 .markOut {
-  background: var(--color-danger);
+  background: var(--color-primary-dark);
 }
 
 .annotationMarker {
@@ -278,7 +278,7 @@
 }
 
 .markOutBtn {
-  background: var(--color-danger);
+  background: var(--color-primary-dark);
   color: var(--text-white);
 }
 

--- a/src/renderer/styles/YouTubeImport.module.css
+++ b/src/renderer/styles/YouTubeImport.module.css
@@ -38,8 +38,8 @@
 
 .urlInput:focus-visible {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: var(--focus-ring);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .urlInput::placeholder {
@@ -79,8 +79,8 @@
 }
 
 .downloadBtn:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .progressSection {

--- a/src/renderer/styles/common.module.css
+++ b/src/renderer/styles/common.module.css
@@ -60,8 +60,8 @@
 }
 
 .button:focus-visible {
-  box-shadow: var(--focus-ring);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Form Styles */

--- a/src/renderer/styles/common.module.css
+++ b/src/renderer/styles/common.module.css
@@ -20,7 +20,7 @@
 
 .buttonPrimary {
   background: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
   box-shadow: var(--shadow-sm);
 }
 
@@ -109,7 +109,7 @@
 
 .input.editing {
   background-color: var(--color-primary);
-  color: var(--text-primary);
+  color: var(--text-white);
   border-color: var(--color-primary);
 }
 

--- a/src/renderer/styles/common.module.css
+++ b/src/renderer/styles/common.module.css
@@ -103,8 +103,8 @@
 
 .input:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: 0 0 0 2px var(--color-primary-light);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 .input.editing {
@@ -133,8 +133,8 @@
 
 .textarea:focus {
   border-color: var(--color-primary);
-  outline: none;
-  box-shadow: 0 0 0 2px var(--color-primary-light);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: 2px;
 }
 
 /* Layout Utilities */

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -7,6 +7,9 @@
   --color-primary-dark: #075450;
   /* The accent on surfaces that are dark whatever the theme (over video). */
   --color-accent-on-dark: #3ed0c2;
+  /* The scrub track needs its own value. --bg-tertiary read 1.38:1 against the
+     transport row, under the 3.0 bar for identifying a control. */
+  --scrub-track: #6a6a6a;
   --color-danger: #f44336;
   --color-danger-dark: #d32f2f;
   --color-danger-light: #ef5350;
@@ -133,6 +136,8 @@
   --focus-ring-color: var(--color-primary);
 
   /* Accent carries over from :root: white reads 5.26:1 on it in either theme. */
+  --scrub-track: #8e8e8e;
+
   --color-success: #1b5e20;
   --color-success-rgb: 27, 94, 32;
   --color-success-dark: #14481a;

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -112,8 +112,14 @@
   --container-max-width: 1200px;
   --min-interactive-size: 44px;
 
-  /* Focus Styles */
-  --focus-ring: 0 0 0 2px var(--color-primary-light);
+  /* Focus Styles.
+     outline, not box-shadow: forced-colors mode on Windows drops shadows, and
+     keyboard users there lost the ring entirely.
+     Worth knowing when testing: an Electron window that does not hold OS focus
+     matches no :focus-visible at all, so the ring reads as missing when the
+     window is simply not focused. */
+  --focus-ring-color: var(--color-accent-on-dark);
+  --focus-ring-width: 2px;
   --focus-ring-within: 0 0 0 2px var(--color-primary);
 
   /* Typefaces. Plex Sans carries interface text rather than Space Grotesk,
@@ -128,6 +134,10 @@
 /* Light theme */
 [data-theme="light"] {
   /* Colors */
+  /* On paper the ring takes the accent itself; the bright face is for dark
+     grounds only. */
+  --focus-ring-color: var(--color-primary);
+
   /* The accent carries over from :root unchanged. White reads at 6.10:1 on it
      in either theme, so the app and the site share one button colour. */
   --color-success: #1b5e20;

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -2,14 +2,11 @@
 :root,
 [data-theme="dark"] {
   /* Colors */
-  /* Teal is the one accent, and it has one job: the clip being cut right now.
-     It sits well clear of the orange band the category presets own, so "act
-     here" can never be read as "this is an offensive possession". */
+  /* The one accent. Clear of the orange band the category presets own. */
   --color-primary: #0b7972;
   --color-primary-dark: #075450;
   --color-primary-light: #0f8f85;
-  /* The accent on a surface that is dark whatever the theme: Present mode and
-     the telestration toolbar both sit over video. */
+  /* The accent on surfaces that are dark whatever the theme (over video). */
   --color-accent-on-dark: #3ed0c2;
   --color-danger: #f44336;
   --color-danger-dark: #d32f2f;
@@ -122,10 +119,8 @@
   --focus-ring-width: 2px;
   --focus-ring-within: 0 0 0 2px var(--color-primary);
 
-  /* Typefaces. Plex Sans carries interface text rather than Space Grotesk,
-     because Space Grotesk has no Greek and el.json needs it. Space Grotesk is
-     for display only. Every fallback stack is real, so a missing font file
-     degrades instead of breaking. */
+  /* Typefaces. Plex Sans carries interface text, not Space Grotesk, which has
+     no Greek and el.json needs it. Space Grotesk is display only. */
   --font-display: "Space Grotesk Variable", "Space Grotesk", system-ui, sans-serif;
   --font-body: "IBM Plex Sans Variable", "IBM Plex Sans", system-ui, sans-serif;
   --font-mono: "IBM Plex Mono", "Monaco", "Menlo", "Ubuntu Mono", monospace;
@@ -138,8 +133,7 @@
      grounds only. */
   --focus-ring-color: var(--color-primary);
 
-  /* The accent carries over from :root unchanged. White reads at 6.10:1 on it
-     in either theme, so the app and the site share one button colour. */
+  /* Accent carries over from :root: white reads 5.26:1 on it in either theme. */
   --color-success: #1b5e20;
   --color-success-rgb: 27, 94, 32;
   --color-success-dark: #14481a;

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -116,8 +116,13 @@
   --focus-ring: 0 0 0 2px var(--color-primary-light);
   --focus-ring-within: 0 0 0 2px var(--color-primary);
 
-  /* Monospace Font */
-  --font-mono: "Monaco", "Menlo", "Ubuntu Mono", monospace;
+  /* Typefaces. Plex Sans carries interface text rather than Space Grotesk,
+     because Space Grotesk has no Greek and el.json needs it. Space Grotesk is
+     for display only. Every fallback stack is real, so a missing font file
+     degrades instead of breaking. */
+  --font-display: "Space Grotesk Variable", "Space Grotesk", system-ui, sans-serif;
+  --font-body: "IBM Plex Sans Variable", "IBM Plex Sans", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", "Monaco", "Menlo", "Ubuntu Mono", monospace;
 }
 
 /* Light theme */

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -5,7 +5,7 @@
   /* Teal is the one accent, and it has one job: the clip being cut right now.
      It sits well clear of the orange band the category presets own, so "act
      here" can never be read as "this is an offensive possession". */
-  --color-primary: #0a6e68;
+  --color-primary: #0b7972;
   --color-primary-dark: #075450;
   --color-primary-light: #0f8f85;
   /* The accent on a surface that is dark whatever the theme: Present mode and

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -2,9 +2,15 @@
 :root,
 [data-theme="dark"] {
   /* Colors */
-  --color-primary: #4caf50;
-  --color-primary-dark: #45a049;
-  --color-primary-light: #66bb6a;
+  /* Teal is the one accent, and it has one job: the clip being cut right now.
+     It sits well clear of the orange band the category presets own, so "act
+     here" can never be read as "this is an offensive possession". */
+  --color-primary: #0a6e68;
+  --color-primary-dark: #075450;
+  --color-primary-light: #0f8f85;
+  /* The accent on a surface that is dark whatever the theme: Present mode and
+     the telestration toolbar both sit over video. */
+  --color-accent-on-dark: #3ed0c2;
   --color-danger: #f44336;
   --color-danger-dark: #d32f2f;
   --color-danger-light: #ef5350;
@@ -117,10 +123,8 @@
 /* Light theme */
 [data-theme="light"] {
   /* Colors */
-  --color-primary: #2e7d32;
-  --color-primary-dark: #1b5e20;
-  --color-primary-light: #388e3c;
-
+  /* The accent carries over from :root unchanged. White reads at 6.10:1 on it
+     in either theme, so the app and the site share one button colour. */
   --color-success: #1b5e20;
   --color-success-rgb: 27, 94, 32;
   --color-success-dark: #14481a;

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -5,7 +5,6 @@
   /* The one accent. Clear of the orange band the category presets own. */
   --color-primary: #0b7972;
   --color-primary-dark: #075450;
-  --color-primary-light: #0f8f85;
   /* The accent on surfaces that are dark whatever the theme (over video). */
   --color-accent-on-dark: #3ed0c2;
   --color-danger: #f44336;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,11 @@ module.exports = (env, argv) => {
           use: [{ loader: "ts-loader" }],
         },
         {
+          test: /\.woff2?$/,
+          type: "asset/resource",
+          generator: { filename: "fonts/[name][ext]" },
+        },
+        {
           test: /\.css$/,
           use: [
             "style-loader",


### PR DESCRIPTION
Recovery PR. Merging the original stack bottom-up with `--delete-branch` removed each base branch before GitHub could retarget the next PR, so #12 and #14 closed unmerged and #13 and #15 landed on intermediate branches. No work was lost, but the per-plan PR split did not survive. This carries everything except plan 019, which merged cleanly as #11.

Supersedes #12, #13, #14, #15. Every commit is intact and individually readable.

## Plans in here
- **018** — the app's action colour moves to the Scorebook teal. `--color-primary` served two jobs that pull opposite ways, a fill behind white text and text on a dark ground; no single hex clears 4.5:1 both ways.
- **020** — typefaces. IBM Plex Sans for interface, Plex Mono for timecodes, Space Grotesk for the wordmark. Self-hosted, verified over `file://` and inside the packaged asar. Space Grotesk has no Greek and `el.json` needs it.
- **021** — contrast. Export Clips and Mark In go 2.78:1 → 5.26:1, the success toast 3.28:1 → 5.83:1.
- **022** — the focus ring becomes an outline across 63 rules in 18 files, because `box-shadow` is dropped in Windows forced-colors mode.

## Review fixes, from four passes
Style, correctness, architecture and an independent design critique all ran after the original PRs were opened:

- Eight rules paired a teal fill with `--text-primary`, white in dark but `#212121` in light, reading 3.06:1.
- The telestration save button was unreadable in light at ~1.9:1. I had treated its toolbar as always-dark; it draws on `--bg-overlay`, which is near-white in light.
- Five focus rings survived the first conversion because they were literal `box-shadow: 0 0 0 2px`, not the token.
- Present mode needed its own ring override, being the one genuinely theme-independent surface.
- The scrub track measured 1.38:1 dark and 1.16:1 light, under the 3.0 bar for identifying a control. Now 3.72:1 and 3.28:1.
- Mark Out was on `--color-danger`, so the pair read as safe-versus-destructive. Both marks take the accent's two faces now. Red appears nowhere in the mark row.

## Testing
`npm run build` green at every commit. Contrast measured from source and verified in the running app in both themes. Fonts verified in the packaged asar.