### PR TITLE
Show one hint at a time in the video area

### DIFF
--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -936,7 +936,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
                 </button>
               </div>
 
-              {showFirstVideoHint && (
+              {showFirstVideoHint && markInTime === null && (
                 <ContextualHint
                   hintId="first-video"
                   message={t("app.hints.markKeys", {


### PR DESCRIPTION
Plan 029. First of four in the batch D stack; merge bottom-up.

Pressing Z stacked a second banner under the first and left the first in place, so the user read "Press Z to mark the start" directly above "Start marked. Now press M", one of which was already wrong. It also cost height at the worst moment, pushing the video pane down while the user watched for the end of a play.

The two conditions are mutually exclusive now, so the mark-out hint replaces the first rather than stacking under it. No new string, so no locale files changed, and both hints still interpolate the user's own key bindings.

## Testing
Verified in the running app against a seeded project: the video element holds 296px through Z and Escape, and the banner swaps rather than stacking.

The two ClipLibrary hints were checked for the same problem, which the plan asked for. They key off `clips.length === 1` and `clips.length >= 3`, so they cannot co-occur.