### PR TITLE
Move toasts clear of the header controls

### DIFF
--- a/src/renderer/styles/Toast.module.css
+++ b/src/renderer/styles/Toast.module.css
@@ -2,11 +2,12 @@
 
 .toastContainer {
   position: fixed;
-  top: var(--spacing-lg);
+  bottom: var(--spacing-lg);
   right: var(--spacing-lg);
   z-index: var(--z-toast);
   display: flex;
-  flex-direction: column;
+  /* Newest nearest the corner, older ones stacking away from it. */
+  flex-direction: column-reverse;
   gap: var(--spacing-sm);
   pointer-events: none;
 }


### PR DESCRIPTION
Plan 025. Stacked on the hint PR.

Toasts were anchored top-right, which is exactly where the header keeps Stats, Settings and the shortcuts button. The feedback for an action covered the controls the user might click next, and sometimes the button they had just pressed.

Bottom-right instead: conventional for a transient confirmation, and it does not depend on the header's height, which a hardcoded top offset would. Stack direction is `column-reverse` so the newest toast sits nearest the corner.

## Testing
Measured in the running app with a real "Switched to Light Mode" toast. It occupies 1168,841 to 1488,897 and covers zero header buttons and zero bottom-panel controls, checked by rectangle intersection rather than by eye.