### PR TITLE
Show categories and quarters that have no clips

### DIFF
--- a/src/renderer/components/StatsDashboard.tsx
+++ b/src/renderer/components/StatsDashboard.tsx
@@ -106,15 +106,17 @@ export const StatsDashboard: React.FC<StatsDashboardProps> = ({
         tally.set(id, cur);
       });
     });
+    // Keep every category, at zero when it has no clips. Absence and zero are
+    // different facts, and for a scouting tool the zero is often the finding.
     const rows = flatCategories
-      .filter(cat => cat.id !== undefined && tally.has(cat.id))
+      .filter(cat => cat.id !== undefined)
       .map(cat => ({
         id: cat.id!,
         name: cat.name,
         color: cat.color,
-        ...tally.get(cat.id!)!,
+        ...(tally.get(cat.id!) ?? { count: 0, duration: 0 }),
       }))
-      .sort((a, b) => b.count - a.count);
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
     const maxCount = rows.reduce((max, r) => Math.max(max, r.count), 0);
     return { rows, maxCount };
   }, [flatCategories, clips]);
@@ -131,9 +133,7 @@ export const StatsDashboard: React.FC<StatsDashboardProps> = ({
         noQuarter += 1;
       }
     });
-    const rows = order
-      .filter(q => counts.has(q))
-      .map(q => ({ label: q, count: counts.get(q)! }));
+    const rows = order.map(q => ({ label: q, count: counts.get(q) ?? 0 }));
     // Any custom quarter values not in the canonical order, sorted for stability
     Array.from(counts.keys())
       .filter(q => !order.includes(q))


### PR DESCRIPTION
Plan 014. Stacked on the toast PR.

Statistics silently omitted any category or quarter with nothing tagged. A coach who tagged nothing in Q4 saw a chart that ran Q1 to Q3 and stopped, and could not tell that apart from a game with no Q4. Absence and zero are different facts, and for a scouting tool the zero is often the finding: "we ran no zone offense in the second half" is a result.

Every category renders now, and every canonical quarter Q1 through OT. Zero rows sort after the rest and then alphabetically so they land in a stable order. Custom quarter values and the no-quarter bucket are untouched.

## Testing
Against a seeded project of 10 clips: the category chart goes from 9 rows to 14, five of them zero, and the quarter chart from 4 rows to 5 with OT at 0. No `NaN` anywhere.

## Two plan steps that were already done
The `maxCount > 0` guard on the bar width already exists, and `.barTrack` already paints a background, so a zero row already shows a track and its `0` label.

Worth flagging separately: that track is `--bg-tertiary`, which measures 1.14:1 against the modal in dark and 1.06:1 in light, so it is barely visible for **any** row. Pre-existing, affects every row rather than just the zero ones, and not fixed here.