### PR TITLE
Keep the Create Clip button on screen

### DIFF
--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -351,7 +351,11 @@
   width: 90%;
   max-width: var(--container-max-width);
   max-height: 90vh;
-  overflow-y: auto;
+  /* The shell does not scroll. The body does, so the header stays pinned at the
+     top and a modal's primary action can pin itself to the bottom. */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   position: relative;
   animation: modalFadeIn var(--transition-normal) ease;
   border: 1px solid var(--border-color);
@@ -413,6 +417,11 @@
 
 .modalBody {
   padding: var(--spacing-lg) var(--spacing-xl);
+  overflow-y: auto;
+  flex: 1 1 auto;
+  /* Required: without it the flex item refuses to shrink and any pinned
+     footer is pushed off screen again. */
+  min-height: 0;
 }
 
 /* Header with Settings Button */

--- a/src/renderer/styles/ClipCreator.module.css
+++ b/src/renderer/styles/ClipCreator.module.css
@@ -1,8 +1,9 @@
 @import "./variables.css";
 
 .clipCreator {
-  height: 100%;
-  overflow-y: auto;
+  /* No overflow of its own. The modal body is the scroll container, and a
+     second one nested inside it gave the sticky action row nothing to stick
+     against. */
   max-width: var(--container-max-width);
   margin: 0 auto;
   padding: var(--spacing-lg);
@@ -117,6 +118,16 @@
 .clipCreationActions {
   display: flex;
   gap: var(--spacing-md);
+  /* The commit action for the app's central task. It pins to the bottom of the
+     modal's scroll area so it is reachable without scrolling past the category
+     tree and the player list. */
+  position: sticky;
+  bottom: calc(var(--spacing-lg) * -1);
+  z-index: 1;
+  background: var(--bg-secondary);
+  padding: var(--spacing-md) 0;
+  margin-top: var(--spacing-md);
+  border-top: 1px solid var(--border-color);
 }
 
 .createClipBtn,


### PR DESCRIPTION
Plan 024. Top of the batch D stack.

A coach marks a play, the form opens, and the button that saves the clip was 260px below the fold. Measured at 1440x900: **Create Clip sat at y=1068 inside an 808px scroll area**, with the player row the last thing visible. That is the app's central task.

## What was actually wrong
The modal shell is a flex column now and does not scroll; the body does. The header was already `position: sticky`, so this just makes the bottom behave like the top.

But the shell was not the obstacle. **ClipCreator's own root had `overflow-y: auto` and was 1022px tall — a second scroll container nested inside the modal body.** A sticky footer stuck to that inner one, which never scrolls, so it never moved. Removing the redundant overflow is what let the action row pin.

## Testing
Create Clip now sits at y=802, inside the modal, at both 1440x900 and 1024x680. The focus trap holds: 40 tabs, zero escapes from the dialog. The button is not focusable until a category is selected, which is its existing disabled behaviour.

Settings and Stats were checked at both sizes. Stats has no primary action. Settings applies changes immediately, and its "Save Preset" is a sub-section control rather than a commit action, so it is left to scroll with its section.