### PR TITLE
Batch D review fixes: toast order, modal padding coupling, dead gate

### DIFF
--- a/src/renderer/components/StatsDashboard.tsx
+++ b/src/renderer/components/StatsDashboard.tsx
@@ -285,28 +285,26 @@ export const StatsDashboard: React.FC<StatsDashboardProps> = ({
       </section>
 
       {/* Clips by quarter */}
-      {byQuarter.rows.length > 0 && (
-        <section className={styles.section}>
-          <h3 className={styles.sectionTitle}>{t("app.stats.byQuarter")}</h3>
-          <div className={styles.barList}>
-            {byQuarter.rows.map(row => (
-              <div key={row.label} className={styles.barRow}>
-                <span className={styles.barLabel} title={row.label}>{row.label}</span>
-                <div className={styles.barTrack}>
-                  <div
-                    className={styles.barFill}
-                    style={{
-                      width: `${byQuarter.maxCount > 0 ? (row.count / byQuarter.maxCount) * 100 : 0}%`,
-                      backgroundColor: "var(--color-primary)",
-                    }}
-                  />
-                </div>
-                <span className={styles.barValue}>{row.count}</span>
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>{t("app.stats.byQuarter")}</h3>
+        <div className={styles.barList}>
+          {byQuarter.rows.map(row => (
+            <div key={row.label} className={styles.barRow}>
+              <span className={styles.barLabel} title={row.label}>{row.label}</span>
+              <div className={styles.barTrack}>
+                <div
+                  className={styles.barFill}
+                  style={{
+                    width: `${byQuarter.maxCount > 0 ? (row.count / byQuarter.maxCount) * 100 : 0}%`,
+                    backgroundColor: "var(--color-primary)",
+                  }}
+                />
               </div>
-            ))}
-          </div>
-        </section>
-      )}
+              <span className={styles.barValue}>{row.count}</span>
+            </div>
+          ))}
+        </div>
+      </section>
 
       {/* Distribution across the game */}
       <section className={styles.section}>

--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -416,7 +416,7 @@
 }
 
 .modalBody {
-  padding: var(--spacing-lg) var(--spacing-xl);
+  padding: var(--modal-body-padding-y) var(--spacing-xl);
   overflow-y: auto;
   flex: 1 1 auto;
   /* Required: without it the flex item refuses to shrink and any pinned

--- a/src/renderer/styles/ClipCreator.module.css
+++ b/src/renderer/styles/ClipCreator.module.css
@@ -122,7 +122,7 @@
      modal's scroll area so it is reachable without scrolling past the category
      tree and the player list. */
   position: sticky;
-  bottom: calc(var(--spacing-lg) * -1);
+  bottom: calc(var(--modal-body-padding-y) * -1);
   z-index: 1;
   background: var(--bg-secondary);
   padding: var(--spacing-md) 0;

--- a/src/renderer/styles/Toast.module.css
+++ b/src/renderer/styles/Toast.module.css
@@ -6,8 +6,9 @@
   right: var(--spacing-lg);
   z-index: var(--z-toast);
   display: flex;
-  /* Newest nearest the corner, older ones stacking away from it. */
-  flex-direction: column-reverse;
+  /* Anchored at the bottom, plain column puts the newest toast last in the
+     stack and so nearest the corner. column-reverse would put the oldest there. */
+  flex-direction: column;
   gap: var(--spacing-sm);
   pointer-events: none;
 }

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -105,6 +105,9 @@
   --input-height: 36px;
   --button-height: 36px;
   --input-padding: var(--spacing-sm) var(--spacing-md);
+  /* Load-bearing: a modal's scrolling body uses this as its vertical padding,
+     and a sticky footer inside it cancels exactly this much to sit flush. */
+  --modal-body-padding-y: var(--spacing-lg);
 
   /* Widths */
   --sidebar-width: 320px;


### PR DESCRIPTION
Follow-up to the batch D stack (#17–#20), from a correctness and an architecture review run after those merged.

## Toast stacking was backwards
Both reviewers found this independently. Moving the container to a `bottom` anchor **and** setting `flex-direction: column-reverse` put the *oldest* toast nearest the corner and pushed each new one away — the opposite of what my own comment claimed. With a bottom anchor, plain `column` is what puts the newest last in the stack and nearest the corner.

Verified with two toasts on screen by comparing DOM order (append order, oldest first) against painted position, so the check doesn't depend on which theme the profile happened to start in.

## A cross-file coupling with nothing holding it together
The sticky footer's `bottom: calc(var(--spacing-lg) * -1)` existed only to cancel `.modalBody`'s bottom padding exactly. Two files, no link between them beyond both spelling `--spacing-lg`. Editing the body's padding would have silently misaligned every sticky footer built against it.

They share `--modal-body-padding-y` now, and the token declares itself load-bearing.

## A guard my own change killed
Including every canonical quarter made `{byQuarter.rows.length > 0 && ...}` dead: `rows` always holds five entries, so it can never be false. Plan 014 explicitly wants Q1 through OT at zero on an empty project, so the section should render and the gate was the thing to remove, not the zeros.

## What the reviews cleared
Hint mutual exclusivity was traced across mount, pre-marked clips, marking, and both-marks-set: exactly one hint or none, in every state. No modal lost its scrolling body. Nothing depended on `ClipCreator`'s removed scroll container. No `NaN` or key collisions from the zero rows. The `StatsDashboard` duplication was judged fine at this size, and the per-modal footer split matches what `FeedbackModal` already does.

## Testing
`npm run build` green. Toast order verified in the running app.