### PR TITLE
Keep the transport on one row

### DIFF
--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -14,6 +14,7 @@ import {
   faForwardStep,
   faBackwardStep,
   faVolumeHigh,
+  faVolumeXmark,
   faLocationPin,
   faTrash,
   faFilm,
@@ -90,6 +91,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
     const [volume, setVolume] = useState(1);
     const [playbackRate, setPlaybackRate] = useState(1);
     const [showSpeedMenu, setShowSpeedMenu] = useState(false);
+  const [showVolumeMenu, setShowVolumeMenu] = useState(false);
     const [keyBindings, setKeyBindings] = useState({
       markInKey: "z",
       markOutKey: "m",
@@ -848,25 +850,38 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
                 </div>
 
                 <div className={styles.volumeControl}>
-                  <span>
-                    <FontAwesomeIcon icon={faVolumeHigh} />
-                  </span>
-                  <input
-                    type="range"
-                    min="0"
-                    max="1"
-                    step="0.1"
-                    value={volume}
-                    onChange={e => {
-                      const newVolume = parseFloat(e.target.value);
-                      setVolume(newVolume);
-                      if (videoRef.current) {
-                        videoRef.current.volume = newVolume;
-                      }
-                    }}
-                    className={styles.volumeSlider}
+                  <button
+                    type="button"
+                    className={styles.speedButton}
+                    onClick={() => setShowVolumeMenu(!showVolumeMenu)}
+                    title={t("app.video.volumeLabel")}
                     aria-label={t("app.video.volumeLabel")}
-                  />
+                    aria-expanded={showVolumeMenu}
+                  >
+                    <FontAwesomeIcon
+                      icon={volume === 0 ? faVolumeXmark : faVolumeHigh}
+                    />
+                  </button>
+                  {showVolumeMenu && (
+                    <div className={styles.volumeMenu}>
+                      <input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.1"
+                        value={volume}
+                        onChange={e => {
+                          const newVolume = parseFloat(e.target.value);
+                          setVolume(newVolume);
+                          if (videoRef.current) {
+                            videoRef.current.volume = newVolume;
+                          }
+                        }}
+                        className={styles.volumeSlider}
+                        aria-label={t("app.video.volumeLabel")}
+                      />
+                    </div>
+                  )}
                 </div>
 
                 <div className={styles.speedControl}>

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -176,7 +176,12 @@
 .controlsRow {
   display: flex;
   align-items: center;
-  gap: var(--spacing-md);
+  gap: var(--spacing-sm);
+  /* wrap is kept so nothing is ever clipped at a small window. The row fits on
+     one line at the common widths because the controls below are sized to fit,
+     not because wrapping is disabled: a flex line break is decided from each
+     item's hypothetical size before any shrinking, so flex-shrink alone cannot
+     prevent a second row. */
   flex-wrap: wrap;
 }
 
@@ -330,10 +335,28 @@
 }
 
 .volumeControl {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
   margin-left: auto;
+}
+
+/* The slider lives in a popover so the transport fits on one row when the side
+   panel is open. Mirrors .speedMenu. */
+.volumeMenu {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm);
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--spacing-sm);
+  box-shadow: var(--shadow-lg);
+  z-index: var(--z-popover);
 }
 
 .volumeSlider {
@@ -514,7 +537,15 @@
   flex-direction: column;
   align-items: center;
   gap: var(--spacing-xs);
-  min-width: 200px;
+  /* 180px is what keeps the whole transport on one row with the side panel
+     open. A fixed 200px min-width here is what made it wrap. */
+  flex: 0 1 180px;
+  min-width: 140px;
+}
+
+.timeSearchContainer > * {
+  min-width: 0;
+  width: 100%;
 }
 
 .timeSearchInput {


### PR DESCRIPTION
Plan 028, first piece. Stacked on #21.

The transport wrapped to two rows whenever the side panel was open, costing 45px of video height and making the layout jump as the panel toggled. The design critique called this out as "a layout collapsing, not a breakpoint". Measured: **1243px of controls in 1048px of space, over by 195px**.

## What closes it
- The volume slider moves into a popover behind its icon, mirroring the speed menu that already worked that way. 112px → 36px. This was your call on the earlier question.
- Row gap 16px → 8px, enough for a dense control strip, saving 112px across fourteen gaps.
- The jump-to-time field loses its fixed 200px floor for a 180px basis, which is what actually let the row fit.

## Two attempts, and why the first was wrong
`flex-wrap` decides a line break from each item's **hypothetical** size, before any shrinking. So `flex-shrink` alone cannot prevent a second row, which is why letting the search field shrink changed nothing.

Switching to `flex-wrap: nowrap` did stop the wrap, but then clipped controls off the right edge at 1180px and below: 971px of content in 632px, with the last control unreachable. That is worse than wrapping. The row keeps `wrap` and is simply sized to fit.

## Measured, side panel open
| Window | Before | After |
|---|---|---|
| 1440x900 | transport 90px, video 275px (30.6%) | transport **42px**, video **323px (35.9%)** |
| 1180x760 | transport 94px, video 71px | transport 86px, video 79px |
| 1024x680 | transport 142px, video 0px | transport 86px, video 0px |

Nothing clipped at any of the three.

## A pre-existing bug this surfaced, not fixed here
**At 1024x680 the video pane collapses to 0px.** Measured identically on the branch *before* this change, so it is not a regression: the bottom panel holds 300px and the control block 217px, and at 680px of window height there is nothing left. The app is unusable at that size today. That is the rest of plan 028 and it wants its own change.