### PR TITLE
Stop the film pane collapsing at a short window

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -220,6 +220,10 @@ const createWindow = (): void => {
   mainWindow = new BrowserWindow({
     height: 1000,
     width: 1600,
+    // The workspace stacks a film pane, five control bands and two panels.
+    // Below this it cannot lay out without starving one of them.
+    minHeight: 700,
+    minWidth: 1000,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -220,10 +220,12 @@ const createWindow = (): void => {
   mainWindow = new BrowserWindow({
     height: 1000,
     width: 1600,
-    // The workspace stacks a film pane, five control bands and two panels.
-    // Below this it cannot lay out without starving one of them.
+    // The workspace stacks a film pane, control bands and two panels. Below
+    // 1280 wide the header title wraps and its buttons spill out of the 60px
+    // bar over the video; below 700 tall the film pane hits its floor and the
+    // clip list is squeezed to its own.
     minHeight: 700,
-    minWidth: 1000,
+    minWidth: 1280,
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -250,22 +250,23 @@ export const App: React.FC = () => {
 
       const startY = e.pageY;
       const startHeight = bottomPanelHeight;
+      // What the user dragged to, which is not the same as what got rendered:
+      // the panel can be shrunk below this by flex when the window is short,
+      // and persisting the rendered height ratcheted the preference down.
+      let draggedHeight = startHeight;
 
       const handleMouseMove = (e: MouseEvent) => {
         if (!isResizing.current) return;
 
         const deltaY = startY - e.pageY; // Inverted for bottom-to-top resize
         const newHeight = Math.min(Math.max(200, startHeight + deltaY), 600);
+        draggedHeight = newHeight;
         setBottomPanelHeight(newHeight);
       };
 
       const handleMouseUp = () => {
         isResizing.current = false;
-        // Save final height on mouseup
-        const finalEl = resizeRef.current;
-        if (finalEl) {
-          savePref(STORAGE_KEYS.BOTTOM_PANEL_HEIGHT, finalEl.clientHeight || bottomPanelHeight);
-        }
+        savePref(STORAGE_KEYS.BOTTOM_PANEL_HEIGHT, draggedHeight);
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
         document.body.style.cursor = "";

--- a/src/renderer/components/ClipLibrary.tsx
+++ b/src/renderer/components/ClipLibrary.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { useDismissableMenu } from "../hooks/useDismissableMenu";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faFilm,
@@ -110,17 +111,12 @@ export const ClipLibrary: React.FC<ClipLibraryProps> = ({
   const [showPresent, setShowPresent] = useState(false);
   const exportMenuRef = useRef<HTMLDivElement>(null);
 
-  // Close export menu on click outside
-  useEffect(() => {
-    if (!exportMenuOpen) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (exportMenuRef.current && !exportMenuRef.current.contains(e.target as Node)) {
-        setExportMenuOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [exportMenuOpen]);
+  // Shared with the transport popovers, so Escape closes all of them alike.
+  useDismissableMenu(
+    exportMenuOpen,
+    useCallback(() => setExportMenuOpen(false), []),
+    [exportMenuRef],
+  );
 
   useEffect(() => {
     loadData();

--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -92,6 +92,30 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
     const [playbackRate, setPlaybackRate] = useState(1);
     const [showSpeedMenu, setShowSpeedMenu] = useState(false);
   const [showVolumeMenu, setShowVolumeMenu] = useState(false);
+
+  // Both transport popovers dismiss on Escape and on a click outside them.
+  useEffect(() => {
+    if (!showSpeedMenu && !showVolumeMenu) return;
+    const close = () => {
+      setShowSpeedMenu(false);
+      setShowVolumeMenu(false);
+    };
+    const onPointerDown = (e: MouseEvent) => {
+      const t = e.target as HTMLElement;
+      if (!t.closest(`.${styles.speedControl}`) && !t.closest(`.${styles.volumeControl}`)) {
+        close();
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [showSpeedMenu, showVolumeMenu]);
     const [keyBindings, setKeyBindings] = useState({
       markInKey: "z",
       markOutKey: "m",
@@ -853,7 +877,10 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
                   <button
                     type="button"
                     className={styles.speedButton}
-                    onClick={() => setShowVolumeMenu(!showVolumeMenu)}
+                    onClick={() => {
+                      setShowSpeedMenu(false);
+                      setShowVolumeMenu(!showVolumeMenu);
+                    }}
                     title={t("app.video.volumeLabel")}
                     aria-label={t("app.video.volumeLabel")}
                     aria-expanded={showVolumeMenu}
@@ -888,7 +915,10 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
                   <button
                     type="button"
                     className={styles.speedButton}
-                    onClick={() => setShowSpeedMenu(!showSpeedMenu)}
+                    onClick={() => {
+                      setShowVolumeMenu(false);
+                      setShowSpeedMenu(!showSpeedMenu);
+                    }}
                     title={t("app.video.playbackSpeed")}
                   >
                     <FontAwesomeIcon icon={faGaugeHigh} />

--- a/src/renderer/components/VideoPlayer.tsx
+++ b/src/renderer/components/VideoPlayer.tsx
@@ -7,6 +7,7 @@ import React, {
   useImperativeHandle,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { useDismissableMenu } from "../hooks/useDismissableMenu";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faPlay,
@@ -93,29 +94,19 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
     const [showSpeedMenu, setShowSpeedMenu] = useState(false);
   const [showVolumeMenu, setShowVolumeMenu] = useState(false);
 
-  // Both transport popovers dismiss on Escape and on a click outside them.
-  useEffect(() => {
-    if (!showSpeedMenu && !showVolumeMenu) return;
-    const close = () => {
+  const speedControlRef = useRef<HTMLDivElement>(null);
+  const volumeControlRef = useRef<HTMLDivElement>(null);
+
+  // Refs rather than class-name lookups: a CSS-module hash is a styling
+  // identifier and nothing ties its shape to this behaviour.
+  useDismissableMenu(
+    showSpeedMenu || showVolumeMenu,
+    useCallback(() => {
       setShowSpeedMenu(false);
       setShowVolumeMenu(false);
-    };
-    const onPointerDown = (e: MouseEvent) => {
-      const t = e.target as HTMLElement;
-      if (!t.closest(`.${styles.speedControl}`) && !t.closest(`.${styles.volumeControl}`)) {
-        close();
-      }
-    };
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") close();
-    };
-    document.addEventListener("mousedown", onPointerDown);
-    document.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      document.removeEventListener("mousedown", onPointerDown);
-      document.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [showSpeedMenu, showVolumeMenu]);
+    }, []),
+    [speedControlRef, volumeControlRef],
+  );
     const [keyBindings, setKeyBindings] = useState({
       markInKey: "z",
       markOutKey: "m",
@@ -873,7 +864,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
                   )}
                 </div>
 
-                <div className={styles.volumeControl}>
+                <div className={styles.volumeControl} ref={volumeControlRef}>
                   <button
                     type="button"
                     className={styles.speedButton}
@@ -911,7 +902,7 @@ export const VideoPlayer = forwardRef<VideoPlayerRef, VideoPlayerProps>(
                   )}
                 </div>
 
-                <div className={styles.speedControl}>
+                <div className={styles.speedControl} ref={speedControlRef}>
                   <button
                     type="button"
                     className={styles.speedButton}

--- a/src/renderer/hooks/useDismissableMenu.ts
+++ b/src/renderer/hooks/useDismissableMenu.ts
@@ -1,0 +1,43 @@
+import { RefObject, useEffect } from "react";
+
+/**
+ * Closes a transient menu when the user clicks outside it or presses Escape.
+ *
+ * Three menus had grown their own version of this: ClipLibrary's export menu
+ * (click-outside only) and the transport's speed and volume popovers. They
+ * disagreed about whether Escape worked, which meant the same gesture closed
+ * one menu and not another.
+ *
+ * Pass every element that counts as "inside". A click landing in any of them
+ * leaves the menu open, which is what lets a trigger button and its popover be
+ * separate elements.
+ */
+export function useDismissableMenu(
+  isOpen: boolean,
+  onDismiss: () => void,
+  insideRefs: RefObject<HTMLElement | null>[],
+): void {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const isInside = (target: Node) =>
+      insideRefs.some(ref => ref.current?.contains(target));
+
+    const onPointerDown = (e: MouseEvent) => {
+      if (!isInside(e.target as Node)) onDismiss();
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onDismiss();
+    };
+
+    document.addEventListener("mousedown", onPointerDown);
+    // Capture, so the menu closes before a component-level Escape handler
+    // treats the key as its own.
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, onDismiss, ...insideRefs]);
+}

--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -63,6 +63,12 @@
   position: relative;
   height: 100%;
   overflow: hidden;
+  /* An explicit floor is required here, not min-height: auto. A flex item's
+     automatic minimum size is zero when it sets overflow: hidden, which this
+     does, so the film pane gave way until it was 0px tall at a 700px window.
+     460px is the worst-case control block (321px, transport wrapped) plus the
+     film's own 140px minimum. The clip list yields instead: it can shrink. */
+  min-height: 460px;
 }
 
 /* Side Panel Styles - for clips library */
@@ -114,9 +120,12 @@
   width: 100%;
   position: relative;
   transition: height 0.2s ease;
-  min-height: 200px;
+  /* The clip list yields before the film does. It used to be flex-shrink: 0
+     with a 200px floor, which is why a short window squeezed the video to
+     nothing instead of squeezing the panel. */
+  min-height: 140px;
   max-height: 600px;
-  flex-shrink: 0;
+  flex-shrink: 1;
 }
 
 .bottomPanelCollapsed {

--- a/src/renderer/styles/App.module.css
+++ b/src/renderer/styles/App.module.css
@@ -66,9 +66,9 @@
   /* An explicit floor is required here, not min-height: auto. A flex item's
      automatic minimum size is zero when it sets overflow: hidden, which this
      does, so the film pane gave way until it was 0px tall at a 700px window.
-     460px is the worst-case control block (321px, transport wrapped) plus the
-     film's own 140px minimum. The clip list yields instead: it can shrink. */
-  min-height: 460px;
+     The value is owned by variables.css, because it is the film's floor plus
+     the transport's worst case and both belong to VideoPlayer. */
+  min-height: var(--video-section-min-height);
 }
 
 /* Side Panel Styles - for clips library */
@@ -123,7 +123,7 @@
   /* The clip list yields before the film does. It used to be flex-shrink: 0
      with a 200px floor, which is why a short window squeezed the video to
      nothing instead of squeezing the panel. */
-  min-height: 140px;
+  min-height: var(--bottom-panel-min-height);
   max-height: 600px;
   flex-shrink: 1;
 }

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -586,6 +586,10 @@
   padding: var(--spacing-xs) var(--spacing-sm);
   outline: none;
   width: 140px;
+  /* Yields with its container rather than overflowing it. The container can be
+     squeezed to its 140px floor, which is less than this field plus the icon
+     and the button need. */
+  min-width: 0;
   font-family: var(--font-mono);
 }
 

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -22,7 +22,7 @@
   /* The film never gets squeezed to nothing. With min-height: 0 the control
      block could take the whole section and leave the video at 0px, which is
      what happened at a 680px window. */
-  min-height: 140px;
+  min-height: var(--video-min-height);
 }
 
 .videoElement {

--- a/src/renderer/styles/VideoPlayer.module.css
+++ b/src/renderer/styles/VideoPlayer.module.css
@@ -19,7 +19,10 @@
   justify-content: center;
   background: var(--bg-main);
   overflow: hidden;
-  min-height: 0;
+  /* The film never gets squeezed to nothing. With min-height: 0 the control
+     block could take the whole section and leave the video at 0px, which is
+     what happened at a 680px window. */
+  min-height: 140px;
 }
 
 .videoElement {

--- a/src/renderer/styles/variables.css
+++ b/src/renderer/styles/variables.css
@@ -10,6 +10,19 @@
   /* The scrub track needs its own value. --bg-tertiary read 1.38:1 against the
      transport row, under the 3.0 bar for identifying a control. */
   --scrub-track: #6a6a6a;
+
+  /* The workspace's vertical floors. These live together because the section
+     floor is derived from the other two, and deriving it by hand one file away
+     is how it goes stale: if the transport grows a control or a locale makes it
+     wrap taller, --video-controls-max only has to change here. */
+  --video-min-height: 140px;
+  --video-controls-max: 320px;
+  --video-section-min-height: calc(
+    var(--video-min-height) + var(--video-controls-max)
+  );
+  /* Independent of --video-min-height despite matching it today: this is how
+     far the clip list may be squeezed, not how tall the film must be. */
+  --bottom-panel-min-height: 140px;
   --color-danger: #f44336;
   --color-danger-dark: #d32f2f;
   --color-danger-light: #ef5350;


### PR DESCRIPTION
Plan 028, part 2. Stacked on #22.

**At a 700px window the video element was 0px tall.** Not small, zero. Found while measuring part 1, and measured on the branch *before* that work to confirm it predates it.

## Three things were wrong together
- The clip list was `flex-shrink: 0` with a 200px floor, so it never yielded.
- The film pane had no floor of its own.
- The app set **no minimum window size at all** — it opens at 1600x1000 but was resizable to anything.

## The CSS rule that caused it
The fix that matters is an explicit `min-height` on `.videoSection`, and it has to be explicit: **a flex item's automatic minimum size is zero when the item sets `overflow: hidden`**, which `.videoSection` does. So `min-height: auto` resolved to 0 rather than to its content, and the pane gave way until nothing was left.

`min-height: auto` is not usable on the wrapping box either — there it resolves to the whole subtree's min-content, about **5500px**, which is how I found the rule.

460px is the worst-case control block (321px, transport wrapped) plus the film's own 140px minimum.

## Measured, side panel open
| Window | video before | video after | clip list after |
|---|---|---|---|
| 1440x900 | 323px | 323px | 300 |
| 1280x800 | 123px | **143px** | 280 |
| 1180x760 | 79px | **139px** | 240 |
| 1000x700 | **0px** | **139px** | 180 |

No page overflow at any size.

## The window minimum, and a correction
I first set 1000x700. That was wrong: measured across widths, **below 1280px the header title wraps to two lines and its buttons spill below the 60px bar, over the video**. The container stays 60px and the content escapes it.

The minimum is 1280x700, which is where the workspace still lays out. The header overflow below that is pre-existing and not fixed here; this just stops the window reaching a size that shows it.