### PR TITLE
Make category colours separate, and stop the timeline relying on them

### DIFF
--- a/src/main/database.ts
+++ b/src/main/database.ts
@@ -755,6 +755,40 @@ const migrateClipColumns = () => {
 
 const insertDefaultCategories = () => {
   try {
+    // The preset rows are seeded with INSERT OR IGNORE, so an install that
+    // already has them would never see a palette change. Re-colour only the
+    // rows still holding the old default: a preset the user has recoloured
+    // keeps their choice, and nobody's existing projects are touched, because
+    // those carry their own colours in the categories table.
+    const repalette: Array<[string, string, string]> = [
+      ["Offense", "#FF5722", "#B15F43"],
+      ["Pick & Roll", "#FF7043", "#A94EBC"],
+      ["Isolation", "#FF8A65", "#3B7B9B"],
+      ["Fast Break", "#FFAB91", "#5D7E30"],
+      ["Post Up", "#FFCCBC", "#BC4E85"],
+      ["Defense", "#2196F3", "#4075BF"],
+      ["Man-to-Man", "#42A5F5", "#1C9C71"],
+      ["Zone Defense", "#64B5F6", "#826BC7"],
+      ["Press", "#90CAF9", "#947538"],
+      ["Transition", "#4CAF50", "#3B9B3B"],
+      ["Rebounding", "#9C27B0", "#A144E4"],
+      ["Offensive Rebound", "#AB47BC", "#D06125"],
+      ["Defensive Rebound", "#BA68C8", "#D4355D"],
+      ["Turnovers", "#F44336", "#D926BB"],
+      ["Special Plays", "#FFC107", "#8F8F14"]
+    ];
+    const repaletteStmt = db.prepare(`
+      UPDATE category_presets SET color = ?
+      WHERE preset_name = 'Basketball' AND category_name = ? AND upper(color) = ?
+    `);
+    let recoloured = 0;
+    for (const [name, oldColor, newColor] of repalette) {
+      recoloured += repaletteStmt.run(newColor, name, oldColor).changes;
+    }
+    if (recoloured > 0) {
+      console.log(`Re-coloured ${recoloured} default category presets`);
+    }
+
     // Check if we already have presets
     const existingPresets = db
       .prepare("SELECT COUNT(*) as count FROM category_presets")
@@ -770,29 +804,29 @@ const insertDefaultCategories = () => {
     // Define default basketball categories with hierarchical structure
     const defaultBasketballPreset = [
       // Offense parent category
-      { name: "Offense", color: "#FF5722", description: "Offensive plays and actions", parent: null, order: 0 },
-      { name: "Pick & Roll", color: "#FF7043", description: "Pick and roll plays", parent: "Offense", order: 1 },
-      { name: "Isolation", color: "#FF8A65", description: "Isolation plays", parent: "Offense", order: 2 },
-      { name: "Fast Break", color: "#FFAB91", description: "Fast break opportunities", parent: "Offense", order: 3 },
-      { name: "Post Up", color: "#FFCCBC", description: "Post up plays", parent: "Offense", order: 4 },
+      { name: "Offense", color: "#B15F43", description: "Offensive plays and actions", parent: null, order: 0 },
+      { name: "Pick & Roll", color: "#A94EBC", description: "Pick and roll plays", parent: "Offense", order: 1 },
+      { name: "Isolation", color: "#3B7B9B", description: "Isolation plays", parent: "Offense", order: 2 },
+      { name: "Fast Break", color: "#5D7E30", description: "Fast break opportunities", parent: "Offense", order: 3 },
+      { name: "Post Up", color: "#BC4E85", description: "Post up plays", parent: "Offense", order: 4 },
 
       // Defense parent category
-      { name: "Defense", color: "#2196F3", description: "Defensive plays and actions", parent: null, order: 5 },
-      { name: "Man-to-Man", color: "#42A5F5", description: "Man-to-man defense", parent: "Defense", order: 6 },
-      { name: "Zone Defense", color: "#64B5F6", description: "Zone defense", parent: "Defense", order: 7 },
-      { name: "Press", color: "#90CAF9", description: "Full or half court press", parent: "Defense", order: 8 },
+      { name: "Defense", color: "#4075BF", description: "Defensive plays and actions", parent: null, order: 5 },
+      { name: "Man-to-Man", color: "#1C9C71", description: "Man-to-man defense", parent: "Defense", order: 6 },
+      { name: "Zone Defense", color: "#826BC7", description: "Zone defense", parent: "Defense", order: 7 },
+      { name: "Press", color: "#947538", description: "Full or half court press", parent: "Defense", order: 8 },
 
       // Transition
-      { name: "Transition", color: "#4CAF50", description: "Transition plays", parent: null, order: 9 },
+      { name: "Transition", color: "#3B9B3B", description: "Transition plays", parent: null, order: 9 },
 
       // Rebounding parent category
-      { name: "Rebounding", color: "#9C27B0", description: "Rebounding situations", parent: null, order: 10 },
-      { name: "Offensive Rebound", color: "#AB47BC", description: "Offensive rebounds", parent: "Rebounding", order: 11 },
-      { name: "Defensive Rebound", color: "#BA68C8", description: "Defensive rebounds", parent: "Rebounding", order: 12 },
+      { name: "Rebounding", color: "#A144E4", description: "Rebounding situations", parent: null, order: 10 },
+      { name: "Offensive Rebound", color: "#D06125", description: "Offensive rebounds", parent: "Rebounding", order: 11 },
+      { name: "Defensive Rebound", color: "#D4355D", description: "Defensive rebounds", parent: "Rebounding", order: 12 },
 
       // Other categories
-      { name: "Turnovers", color: "#F44336", description: "Turnovers and mistakes", parent: null, order: 13 },
-      { name: "Special Plays", color: "#FFC107", description: "Set plays and special situations", parent: null, order: 14 },
+      { name: "Turnovers", color: "#D926BB", description: "Turnovers and mistakes", parent: null, order: 13 },
+      { name: "Special Plays", color: "#8F8F14", description: "Set plays and special situations", parent: null, order: 14 },
     ];
 
     const insertStmt = db.prepare(`

--- a/src/renderer/components/CategoryManager.tsx
+++ b/src/renderer/components/CategoryManager.tsx
@@ -18,22 +18,25 @@ import { Category } from "../../types/global";
 
 const DEFAULT_CATEGORY_COLOR = "#4CAF50";
 
+// Kept in step with the Basketball preset seeded in src/main/database.ts.
+// Every pair is at least CIE76 dE 23.7 apart, clears 3:1 on both theme
+// backgrounds, and sits 25 or more from the action and danger colours.
 const colorPresets: Array<{ hex: string; name: string }> = [
-  { hex: "#4CAF50", name: "Green" },
-  { hex: "#2196F3", name: "Blue" },
-  { hex: "#FF9800", name: "Orange" },
-  { hex: "#f44336", name: "Red" },
-  { hex: "#9C27B0", name: "Purple" },
-  { hex: "#00BCD4", name: "Cyan" },
-  { hex: "#8BC34A", name: "Light Green" },
-  { hex: "#FFC107", name: "Amber" },
-  { hex: "#E91E63", name: "Pink" },
-  { hex: "#795548", name: "Brown" },
-  { hex: "#607D8B", name: "Blue Grey" },
-  { hex: "#FF5722", name: "Deep Orange" },
-  { hex: "#3F51B5", name: "Indigo" },
-  { hex: "#009688", name: "Teal" },
-  { hex: "#CDDC39", name: "Lime" },
+  { hex: "#B15F43", name: "Terracotta" },
+  { hex: "#A94EBC", name: "Violet" },
+  { hex: "#3B7B9B", name: "Steel blue" },
+  { hex: "#5D7E30", name: "Olive" },
+  { hex: "#BC4E85", name: "Raspberry" },
+  { hex: "#4075BF", name: "Blue" },
+  { hex: "#1C9C71", name: "Jade" },
+  { hex: "#826BC7", name: "Periwinkle" },
+  { hex: "#947538", name: "Bronze" },
+  { hex: "#3B9B3B", name: "Green" },
+  { hex: "#A144E4", name: "Purple" },
+  { hex: "#D06125", name: "Burnt orange" },
+  { hex: "#D4355D", name: "Crimson" },
+  { hex: "#D926BB", name: "Magenta" },
+  { hex: "#8F8F14", name: "Citron" },
 ];
 
 interface CategoryManagerProps {

--- a/src/renderer/components/CategoryManager.tsx
+++ b/src/renderer/components/CategoryManager.tsx
@@ -16,7 +16,10 @@ import { useConfirm } from "../contexts/ConfirmContext";
 
 import { Category } from "../../types/global";
 
-const DEFAULT_CATEGORY_COLOR = "#4CAF50";
+// A category with no colour of its own. Deliberately a neutral: it reads as
+// unset rather than impersonating a real category. The old #4CAF50 sat dE 7.4
+// from Transition in the new palette and failed 3:1 on the light theme.
+const DEFAULT_CATEGORY_COLOR = "#7F7F7F";
 
 // Kept in step with the Basketball preset seeded in src/main/database.ts.
 // Every pair is at least CIE76 dE 23.7 apart, clears 3:1 on both theme

--- a/src/renderer/components/Timeline.tsx
+++ b/src/renderer/components/Timeline.tsx
@@ -14,7 +14,10 @@ import {
 
 import { Clip, Category } from "../../types/global";
 
-const DEFAULT_CATEGORY_COLOR = "#4CAF50";
+// A category with no colour of its own. Deliberately a neutral: it reads as
+// unset rather than impersonating a real category. The old #4CAF50 sat dE 7.4
+// from Transition in the new palette and failed 3:1 on the light theme.
+const DEFAULT_CATEGORY_COLOR = "#7F7F7F";
 
 interface TimelineProps {
   clips: Clip[];

--- a/src/renderer/components/Timeline.tsx
+++ b/src/renderer/components/Timeline.tsx
@@ -516,11 +516,13 @@ export const Timeline: React.FC<TimelineProps> = ({
 
               {/* Timeline Tracks */}
               <div className={styles.timelineTracks}>
-                {clipsByCategory.map(({ category, clips: categoryClips }) => (
+                {clipsByCategory.map(({ category, clips: categoryClips }, trackIndex) => (
                   <div key={category.id} className={styles.timelineTrack}>
                     <div className={styles.trackLabelSticky}>
                       <div
-                        className={styles.trackColorIndicator}
+                        className={`${styles.trackColorIndicator} ${
+                          styles[`markerShape${trackIndex % 3}`]
+                        }`}
                         style={{ backgroundColor: category.color }}
                       />
                       <span
@@ -549,8 +551,8 @@ export const Timeline: React.FC<TimelineProps> = ({
                         <div
                           key={clip.id}
                           className={`${styles.timelineClip} ${
-                            selectedClip?.id === clip.id ? styles.selectedClip : ""
-                          }`}
+                            styles[`markerShape${trackIndex % 3}`]
+                          } ${selectedClip?.id === clip.id ? styles.selectedClip : ""}`}
                           style={{
                             left: `${clip.startPercentage}%`,
                             width: `${clip.widthPercentage}%`,

--- a/src/renderer/styles/Timeline.module.css
+++ b/src/renderer/styles/Timeline.module.css
@@ -775,5 +775,10 @@
 }
 
 .markerShape2 {
-  box-shadow: inset 0 0 0 2px var(--bg-secondary);
+  /* outline, not box-shadow: .selectedClip sets its own box-shadow and would
+     replace this one, so selecting a clip removed the very signal that tells
+     its lane apart. A negative offset draws the ring inside without affecting
+     layout. */
+  outline: 2px solid var(--bg-secondary);
+  outline-offset: -2px;
 }

--- a/src/renderer/styles/Timeline.module.css
+++ b/src/renderer/styles/Timeline.module.css
@@ -754,3 +754,26 @@
   box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
 }
 
+
+/* A second signal on every lane, so the tracks stay separable without colour.
+   Category colour cannot carry fifteen categories for a colourblind user: with
+   each swatch also clearing 3:1 on both theme backgrounds, the lightness range
+   is pinned and only seven colours stay distinguishable. Shape covers the rest.
+   Three variants cycle by track index, and a lane's dot matches its markers. */
+.markerShape0 {
+  /* solid */
+}
+
+.markerShape1 {
+  background-image: linear-gradient(
+    to bottom,
+    transparent 36%,
+    rgba(255, 255, 255, 0.9) 36%,
+    rgba(255, 255, 255, 0.9) 64%,
+    transparent 64%
+  );
+}
+
+.markerShape2 {
+  box-shadow: inset 0 0 0 2px var(--bg-secondary);
+}


### PR DESCRIPTION
Plan 023. Stacked on #24.

## The measurement
The default palette was one Material hue per parent with lighter tints for its children, so siblings collided by construction. In CIELAB, **12 of 105 pairs sat under ΔE 22**:

| ΔE (CIE76) | Pair |
|---|---|
| 9.9 | Defense / Man-to-Man |
| 10.7 | Man-to-Man / Zone Defense |
| 11.0 | Rebounding / Offensive Rebound |
| 13.4 | Zone Defense / Press |
| 14.6 | Offensive Rebound / Defensive Rebound |
| 15.1 | Offense / Pick & Roll |

The new palette gives every category its own hue: **minimum pairwise ΔE 23.7**, every colour clears **3:1 against both** theme backgrounds, and none is within **25** of the action or danger colours. Hierarchy is carried by the `└` glyph and indent, which already existed.

## Colour alone cannot do this, and the arithmetic says so
Requiring one hex to clear 3:1 on both `#2a2a2a` and `#f5f5f5` pins its luminance to a narrow band — and lightness is most of what a deuteranope discriminates with.

| Swatch contrast | Normal vision | Also colourblind-safe |
|---|---|---|
| ≥3:1 both themes | 16 colours | **7** |
| ≥2.5:1 both themes | 16 colours | 12 |
| unconstrained | 16 colours | 16 |

The preset has 15 categories. **You chose to keep 3:1 and add a second signal**, so every lane now carries a shape as well as a colour — solid, banded, or hollow, cycling by track, on both the markers and the lane's own dot. Verified on a greyscale render: the lanes stay separable with no colour at all.

## The migration
The preset rows are seeded with `INSERT OR IGNORE` behind an early return, so **an existing install would never have seen any of this**. A migration re-colours only preset rows still holding the old default, placed above that early return so it actually runs.

Verified on a seeded profile: 15 presets updated, zero old hexes left, a preset the user had recoloured kept its value, and the existing project's own categories were untouched — which is the point, since those carry their own colours.

## Two collisions the change exposed
- `DEFAULT_CATEGORY_COLOR` was still `#4CAF50`, which sits **ΔE 7.4** from the new Transition and fails light-theme contrast at 2.55:1. "No colour set" would have looked like a real category. It is a neutral now, ΔE 26 from everything.
- `.markerShape2` drew its ring with an inset `box-shadow`, and `.selectedClip` sets its own at higher specificity. `box-shadow` does not accumulate, so **selecting a clip removed the signal that identified its lane**. It is an `outline` with a negative offset now, and both survive.